### PR TITLE
feat(products): implement size and color selectors for product details

### DIFF
--- a/src/pages/products/[id].astro
+++ b/src/pages/products/[id].astro
@@ -38,71 +38,108 @@ export async function getStaticPaths() {
       <div>
         <h2>Color:</h2>
         <p>Color dinámico</p>
-        <span>Color 1</span>
-        <span>Color 2</span>
-      </div>
-      <div>
-        <h2>Seleccioná tu Talle:</h2>
-        <div class="flex gap-2 p-2">
+        <div class="flex gap-3 py-2">
           <label class="cursor-pointer">
             <input
               type="radio"
-              name="size"
-              id="size-s"
-              value="s"
+              name="color"
+              value="slate"
               class="sr-only peer"
+              checked
             />
             <span
-              class="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors"
-              >S
-            </span>
-          </label>
-
-          <label class="cursor-pointer">
-            <input
-              type="radio"
-              name="size"
-              id="size-m"
-              value="m"
-              class="sr-only peer"
-            />
-            <span
-              class="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors"
-              >M</span
-            >
+              class="w-6 h-6 inline-block rounded-full bg-slate-400 peer-checked:ring-2 peer-checked:ring-offset-2 peer-checked:ring-gray-400"
+              aria-label="Color Gris"></span>
           </label>
           <label class="cursor-pointer">
             <input
               type="radio"
-              name="size"
-              id="size-l"
-              value="l"
+              name="color"
+              value="blue"
               class="sr-only peer"
             />
             <span
-              class="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors"
-              >L</span
-            >
+              class="w-6 h-6 inline-block rounded-full bg-blue-400 peer-checked:ring-2 peer-checked:ring-offset-2 peer-checked:ring-gray-400"
+              aria-label="Color Azul"></span>
           </label>
-
           <label class="cursor-pointer">
             <input
               type="radio"
-              name="size"
-              id="size-xl"
-              value="xl"
+              name="color"
+              value="black"
               class="sr-only peer"
             />
             <span
-              class="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors"
-              >XL</span
-            ></label
-          >
+              class="w-6 h-6 inline-block rounded-full bg-black peer-checked:ring-2 peer-checked:ring-offset-2 peer-checked:ring-gray-400"
+              aria-label="Color Negro"></span>
+          </label>
         </div>
-        <p>(?) Ver Guía de Talles</p>
+        <div>
+          <h2>Seleccioná tu Talle:</h2>
+          <div class="flex gap-2 py-2">
+            <label class="cursor-pointer">
+              <input
+                type="radio"
+                name="size"
+                id="size-s"
+                value="s"
+                class="sr-only peer"
+                checked
+              />
+              <span
+                class="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors"
+                >S
+              </span>
+            </label>
+            <label class="cursor-pointer">
+              <input
+                type="radio"
+                name="size"
+                id="size-m"
+                value="m"
+                class="sr-only peer"
+              />
+              <span
+                class="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors"
+                >M</span
+              >
+            </label>
+            <label class="cursor-pointer">
+              <input
+                type="radio"
+                name="size"
+                id="size-l"
+                value="l"
+                class="sr-only peer"
+              />
+              <span
+                class="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors"
+                >L</span
+              >
+            </label>
+            <label class="cursor-pointer">
+              <input
+                type="radio"
+                name="size"
+                id="size-xl"
+                value="xl"
+                class="sr-only peer"
+              />
+              <span
+                class="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors"
+                >XL</span
+              >
+            </label>
+          </div>
+          <p class="underline py-2">(?) Ver Guía de Talles</p>
+        </div>
+        <p>{product?.description}</p>
+        <button
+          type="button"
+          class="cursor-pointer bg-orange-400 p-2 my-2 rounded-lg w-70 text-slate-800 font-bold"
+          >Agregar al Carrito</button
+        >
       </div>
-      <p>{product?.description}</p>
-      <button type="button">Agregar al Carrito</button>
     </div>
   </section>
 </Layout>


### PR DESCRIPTION
## What changed?
* Created `[id].astro` to handle dynamic product details display.   
* Implemented a size selection system using radio buttons and `peer` states in `[id].astro`.
* Added interactive color swatches with focus rings and accessibility labels.
* Integrated product data from `products.ts` to power the dynamic routes.
* Improved the product detail page layout for better responsiveness.

## Why?
* This change allows users to view specific product information and select their preferred size and color before adding items to the cart.
* Closes #22.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to any product card on the home page and click on it.
3. Verify that the product detail page loads with the correct information (name, price, image).
4. Interact with the size buttons (S, M, L, XL) and ensure the active state changes.
5. Interact with the color swatches and verify the visual selection indicator.

**Optional**:
## Screenshots (UI changes)
<img width="1901" height="959" alt="image" src="https://github.com/user-attachments/assets/b461c5ab-bfa4-48ff-aea4-d23e57c265cc" />
<img width="475" height="427" alt="image" src="https://github.com/user-attachments/assets/34003a27-92b9-4335-95e1-66d8f8dcb460" />

