### PR TITLE
docs(readme): add last commit badge and update badge styles #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 <div align="center">
   
-![Astro](https://img.shields.io/badge/Astro-0C1120?style=for-the-badge&logo=astro&logoColor=white)
-![React](https://img.shields.io/badge/React-20232a?style=for-the-badge&logo=react&logoColor=61DAFB)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-38B2AC?style=for-the-badge&logo=tailwind-css&logoColor=white)
-![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
+![Astro](https://img.shields.io/badge/Astro-0C1120?style=plastic&logo=astro&logoColor=white)
+![React](https://img.shields.io/badge/React-20232a?style=plastic&logo=react&logoColor=61DAFB)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-38B2AC?style=plastic&logo=tailwind-css&logoColor=white)
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=plastic&logo=javascript&logoColor=black)
+![GitHub last commit](https://img.shields.io/github/last-commit/rosacabrerac/abrigate-bien-store?style=plastic)
+
 
 </div>
 


### PR DESCRIPTION
## What changed?
* Added a new GitHub "Last Commit" badge to the top section of `README.md`.
* Updated the style of all existing technology badges (Astro, React, Tailwind CSS, JavaScript) to use the `plastic` style for a consistent visual presentation.

## Why?
* This change allows visitors and recruiters to quickly see the latest activity and maintenance status of the repository.
* The update to all badges ensures a cohesive and polished look in the project's documentation.
* Closes #6.

## How to test
1. Go to the project's main repository page on GitHub.
2. Verify that the "Last Commit" badge is rendered correctly in the header.
3. Check that all technology badges share the same `plastic` visual style.

**Optional**:
## Screenshots (UI changes)
<img width="589" height="176" alt="image" src="https://github.com/user-attachments/assets/1acc15ef-0961-41a8-a11f-69b4ec6e498b" />

