### PR TITLE
feature(cart): improve accessibility and focus management

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -1,4 +1,5 @@
 import { useStore } from "@nanostores/react";
+import { useEffect, useRef } from "react";
 import {
   cartItems,
   clearCart,
@@ -11,6 +12,19 @@ export default function CartDrawer() {
   const $isCartOpen = useStore(isCartOpen);
   const $cartItems = useStore(cartItems);
 
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if ($isCartOpen) {
+      const elementToReturnFocus = document.activeElement as HTMLElement;
+      closeButtonRef.current?.focus();
+
+      return () => {
+        elementToReturnFocus.focus();
+      };
+    }
+  }, [$isCartOpen]);
+
   if (!$isCartOpen) return null;
 
   const isNotEmpty = Object.keys($cartItems).length > 0;
@@ -21,9 +35,26 @@ export default function CartDrawer() {
         type="button"
         className="fixed inset-0 bg-black/50 z-40 border-none"
         aria-label="Cerrar carrito"
+        tabIndex={-1}
         onClick={() => isCartOpen.set(false)}
       ></button>
-      <aside className="fixed right-0 top-0 h-full w-100 bg-white shadow-xl z-50 p-4">
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Carrito de compras"
+        className="fixed right-0 top-0 h-full w-100 bg-white shadow-xl z-50 p-4 "
+      >
+        <div className="flex justify-end">
+          <button
+            type="button"
+            ref={closeButtonRef}
+            onClick={() => isCartOpen.set(false)}
+            className="p-2 hover:bg-gray-100 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500"
+            aria-label="Cerrar carrito"
+          >
+            X
+          </button>
+        </div>
         <ul>
           {Object.values($cartItems).map((item) => (
             <li key={`${item.id}-${item.size}`}>

--- a/src/components/CartIcon.tsx
+++ b/src/components/CartIcon.tsx
@@ -18,7 +18,7 @@ export default function CartIcon() {
   return (
     <button
       type="button"
-      className="relative bg-transparent border-none cursor-pointer"
+      className="relative bg-transparent border-none cursor-pointer focus:outline-none focus:ring focus:ring-amber-500 rounded-lg"
       onClick={() => toggleCart()}
     >
       <svg


### PR DESCRIPTION
## What changed?
* Updated `CartDrawer.tsx` to include an explicit close button with proper focus styles.
* Implemented focus management in `CartDrawer.tsx` using `useRef` and `useEffect` to focus the close button upon opening and return focus to the trigger element upon closing.
* Added `role="dialog"`, `aria-modal="true"`, and `aria-label` attributes to the `CartDrawer` for better screen reader support.
* Updated `CartIcon.tsx` button with focus ring styles to improve keyboard navigation visibility.

## Why?
* These changes ensure the shopping cart is fully accessible to keyboard and screen reader users, following WAI-ARIA best practices for dialog components.
* Closes #50.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to the home page.
3. Click on the cart icon to open the drawer; verify that the focus automatically moves to the new "X" close button.
4. Press the `Esc` key or click the close button/backdrop to close the drawer; verify that the focus returns to the cart icon.
5. Tab through the interface to verify that focus rings are clearly visible on both the cart icon and the drawer's close button.

**Optional**:
## Screenshots
<img width="403" height="616" alt="image" src="https://github.com/user-attachments/assets/193866df-9949-4895-922d-b72a37147fd9" />
<img width="367" height="46" alt="image" src="https://github.com/user-attachments/assets/05f574e9-d467-4572-a19e-55d250c6cfa5" />
