### PR TITLE
feat(cart): implement visual feedback for cart actions

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,7 @@
+pre-commit:
+  parallel: true
+  commands:
+    biome-check:
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,astro}"
+      run: pnpm biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "astro": "astro",
     "lint": "biome check",
     "check": "astro check",
-    "format": "biome format --write"
+    "format": "biome check --write"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.8",
@@ -29,6 +29,7 @@
     "@biomejs/biome": "^2.4.7",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",
+    "lefthook": "^2.1.9",
     "typescript": "^5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^20.4.3
         version: 20.5.0
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1542,6 +1545,60 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+    hasBin: true
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -3949,6 +4006,49 @@ snapshots:
   jsonc-parser@3.3.1: {}
 
   kleur@4.1.5: {}
+
+  lefthook-darwin-arm64@2.1.9:
+    optional: true
+
+  lefthook-darwin-x64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.9:
+    optional: true
+
+  lefthook-linux-arm64@2.1.9:
+    optional: true
+
+  lefthook-linux-x64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.9:
+    optional: true
+
+  lefthook-windows-arm64@2.1.9:
+    optional: true
+
+  lefthook-windows-x64@2.1.9:
+    optional: true
+
+  lefthook@2.1.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   lightningcss-android-arm64@1.31.1:
     optional: true

--- a/src/components/CartIcon.tsx
+++ b/src/components/CartIcon.tsx
@@ -4,6 +4,7 @@ import { cartItems, toggleCart } from "../store/cartStore";
 
 export default function CartIcon() {
   const [mounted, setMounted] = useState(false);
+  const [animate, setAnimate] = useState(false);
 
   useEffect(() => {
     setMounted(true);
@@ -14,6 +15,18 @@ export default function CartIcon() {
     (accumulator, item) => accumulator + item.quantity,
     0,
   );
+
+  useEffect(() => {
+    if (totalItems > 0) {
+      setAnimate(true);
+      const animateCart = setTimeout(() => {
+        setAnimate(false);
+      }, 300);
+      return () => {
+        clearTimeout(animateCart);
+      };
+    }
+  }, [totalItems]);
 
   return (
     <button
@@ -39,7 +52,9 @@ export default function CartIcon() {
         <path d="M9 11v-5a3 3 0 0 1 6 0v5" />
       </svg>
       {mounted && totalItems > 0 && (
-        <span className="absolute text-white bg-amber-600 rounded-full top-0 right-0 w-5 h-5 flex items-center justify-center p-1">
+        <span
+          className={`absolute text-white bg-amber-600 rounded-full top-0 right-0 w-5 h-5 flex items-center justify-center p-1 transition-transform duration-150 ${animate ? "scale-125" : "scale-100"}`}
+        >
           {totalItems}
         </span>
       )}

--- a/src/components/CartInteraction.tsx
+++ b/src/components/CartInteraction.tsx
@@ -5,6 +5,7 @@ import { addItemsToCart } from "../store/cartStore";
 export default function CartInteraction({ product }: { product: Product }) {
   const [selectedSize, setSelectedSize] = useState("S");
   const [selectedColor, setSelectedColor] = useState("Slate");
+  const [isAdded, setIsAdded] = useState(false);
 
   const handleAddToCart = () => {
     const itemToBeAdded = {
@@ -19,6 +20,12 @@ export default function CartInteraction({ product }: { product: Product }) {
     };
 
     addItemsToCart(itemToBeAdded);
+
+    setIsAdded(true);
+
+    setTimeout(() => {
+      setIsAdded(false);
+    }, 2000);
   };
 
   return (
@@ -126,10 +133,11 @@ export default function CartInteraction({ product }: { product: Product }) {
       </div>
       <button
         type="button"
-        className="flex items-center justify-center gap-2 text-center cursor-pointer bg-orange-400 p-2 my-2 rounded-lg w-90 text-slate-800 font-bold"
+        className={`flex items-center justify-center gap-2 text-center cursor-pointer p-2 my-2 rounded-lg w-90 text-slate-800 font-bold transition-colors duration-300 ${isAdded ? "bg-emerald-500" : "bg-orange-400"}`}
         onClick={handleAddToCart}
+        disabled={isAdded}
       >
-        Añadir al Carrito
+        {isAdded ? "¡Añadido!" : "Añadir al Carrito"}
       </button>
     </div>
   );

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,0 +1,39 @@
+import { useStore } from "@nanostores/react";
+import { useEffect } from "react";
+import { removeToast, type Toast, toasts } from "../store/cartStore";
+
+function ToastItem({ toast }: { toast: Toast }) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      removeToast(toast.id);
+    }, 3000);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [toast.id]);
+
+  return (
+    <div className="bg-slate-900 text-white p-4 rounded-lg shadow-lg flex justify-between gap-4 border border-slate-700">
+      <span>{toast.message}</span>
+      <button
+        type="button"
+        onClick={() => removeToast(toast.id)}
+        className="text-red-400 hover:text-red-300"
+      >
+        X
+      </button>
+    </div>
+  );
+}
+
+export default function ToastContainer() {
+  const toastList = useStore(toasts);
+
+  return (
+    <div className="flex flex-col gap-2 fixed bottom-4 right-4 z-50">
+      {toastList.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import "../styles/global.css";
 import CartDrawer from "../components/CartDrawer";
 import Footer from "../components/Footer.astro";
 import Navbar from "../components/Navbar.astro";
+import ToastContainer from "../components/ToastContainer";
 
 interface Props {
   title?: string;
@@ -32,6 +33,7 @@ const { title = "Abrigate Bien Store 🔥" } = Astro.props;
   >
     <Navbar />
     <CartDrawer client:load/>
+    <ToastContainer client:load />
     <main class="flex-grow">
       <slot />
     </main>

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -37,6 +37,12 @@ export function addItemsToCart(item: CartItem) {
       [cartItemId]: { ...item, quantity: 1 },
     });
   }
+  const newToast: Toast = {
+    id: Math.random().toString(),
+    message: `¡Añadido al carrito: ${item.name}! 🧥`,
+  };
+
+  toasts.set([...toasts.get(), newToast]);
 }
 
 export function getWhatsAppUrl() {
@@ -82,4 +88,15 @@ export function removeItemFromCart(cartItemId: string) {
     delete newCart[cartItemId];
   }
   cartItems.set(newCart);
+}
+
+export type Toast = {
+  id: string;
+  message: string;
+};
+
+export const toasts = atom<Toast[]>([]);
+
+export function removeToast(id: string) {
+  toasts.set(toasts.get().filter((toast) => toast.id !== id));
 }


### PR DESCRIPTION
## What changed?
* Implemented a reactive notification store atom `toasts` and a `removeToast` action inside `src/store/cartStore.ts`.
* Created `ToastContainer.tsx` and `ToastItem` React components inside `src/components/ToastContainer.tsx` to subscribe to the store, display active notifications, and handle auto-dismissal through cleanup-safe timeouts.
* Mounted the `ToastContainer.tsx` component inside `src/layouts/Layout.astro` to make toast alerts globally available.
* Implemented a subtle scale-up transition animation in `src/components/CartIcon.tsx` triggered on item count updates.
* Added a dynamic success state (text change, color change, and temporary disable status) to the add-to-cart button in `src/components/CartInteraction.tsx` upon adding an item.

## Why?
* Provides immediate Shopper feedback when adding items to their cart.
* Closes #41.

## How to test
1. Ensure the development server is running (`pnpm dev`).
2. Navigate to any product page (e.g., a dynamic product slug page).
3. Select a size, color, and click the "Añadir al Carrito" button.
4. Verify that a toast notification appears at the bottom-right corner and auto-dismisses after 3 seconds.
5. Verify that the cart badge in the navbar scales up and down for a brief duration of 150ms.
6. Verify that the clicked button turns green showing "¡Añadido!" and remains disabled for 2 seconds.

## Screenshots (UI changes)
<img width="1910" height="956" alt="image" src="https://github.com/user-attachments/assets/50477973-0439-4ef5-b96d-80d14d7b5673" />
