### PR TITLE
refactor(styles): extract repeated Tailwind class strings to `@utility`

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -1,0 +1,55 @@
+# Skill Registry - abrigate-bien-store
+
+## System Skills
+- **sdd-init**: Initialize project context (Active)
+- **sdd-explore**: Investigate ideas and codebase
+- **sdd-propose**: Create change proposals
+- **sdd-spec**: Write technical specifications
+- **sdd-design**: Create technical designs
+- **sdd-tasks**: Break down implementation tasks
+- **sdd-apply**: Implement code changes
+- **sdd-verify**: Validate implementation
+- **sdd-archive**: Finalize and sync changes
+- **judgment-day**: Adversarial review protocol
+
+## Project Skills (.agents/skills)
+- **commit-generator**: Automated conventional commits
+- **issue-generator**: GitHub issue creation from context
+- **pr-generator**: Pull Request description generator
+- **accessibility**: WCAG 2.2 audit and remediation
+- **seo**: SEO optimization and auditing
+- **astro**: Astro component and page development
+- **tailwind-css-patterns**: TailwindCSS v4 utility-first styling patterns
+- **composition-patterns**: React composition patterns
+- **container-presentational-pattern**: Separation of logic and presentation in components
+- **react-best-practices**: Performance and best practices for React/Astro
+- **typescript-advanced-types**: Generic and advanced TypeScript typings
+- **frontend-design**: Premium aesthetics and design patterns
+- **nodejs-backend-patterns**: Node.js backend services and middleware patterns
+- **nodejs-best-practices**: Node.js development principles
+
+## Project Standards (Compact Rules)
+- **Framework**: Astro v6 + React v19 (follow official best practices and integration guidelines)
+- **Styling**: TailwindCSS v4 (utility-first, premium aesthetics, use design tokens)
+- **Linting & Formatting**: Biome for linter/formatter (run `pnpm lint --write`) and Prettier for Astro formatting (run `pnpm format`)
+- **Language & Format**: English for PRs, Issues, Commits, and Documentation. Spanish (Rioplatense) for communication and UI.
+- **Git Flow**: Atomic Commits (one logical change per commit) via conventional commits.
+- **Architecture**: Screaming Architecture (`src/features/...` or feature-focused directory structure).
+- **Component Pattern**: React Composition Pattern, Container/Presentational Pattern (split state/stores from presentation).
+- **SVG Isolation**: Reusable icons under `src/components/icons/` instead of hardcoded XML.
+- **Clean Tailwind**: Avoid long class strings (chorizos) by breaking them down or using `@utility` in `global.css`.
+- **Design Tokens**: Centralized variables defined in `@theme` of `global.css` (e.g. `--color-brand`, `--color-bg`, no arbitrary colors).
+- **Core Principles**: SRP, DRY, KISS, YAGNI.
+- **NO COMMENTS RULE**: STRICTLY PROHIBITED to leave structural, redundant, or unnecessary comments in code.
+
+## Testing Capabilities
+- **Unit/Integration**: None configured (consider adding Vitest)
+- **E2E**: None configured (consider adding Playwright)
+- **Linter/Formatter**: Biome
+- **Type Checking**: TypeScript (tsc)
+- **Strict TDD Mode**: Disabled
+
+## Persistence Protocol
+- Every completed SDD phase MUST be saved to `openspec/` AND `engram`.
+- Topic key format: `sdd/{change-name}/{artifact-type}`.
+- Use `mem_save` for architectural decisions, bug fixes, and non-obvious findings.

--- a/src/components/CartInteraction.tsx
+++ b/src/components/CartInteraction.tsx
@@ -84,9 +84,7 @@ export default function CartInteraction({ product }: { product: Product }) {
             checked={selectedSize === "S"}
             onChange={() => setSelectedSize("S")}
           />
-          <span className="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors">
-            S
-          </span>
+          <span className="size-selector">S</span>
         </label>
         <label className="cursor-pointer">
           <input
@@ -98,9 +96,7 @@ export default function CartInteraction({ product }: { product: Product }) {
             checked={selectedSize === "M"}
             onChange={() => setSelectedSize("M")}
           />
-          <span className="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors">
-            M
-          </span>
+          <span className="size-selector">M</span>
         </label>
         <label className="cursor-pointer">
           <input
@@ -112,9 +108,7 @@ export default function CartInteraction({ product }: { product: Product }) {
             checked={selectedSize === "L"}
             onChange={() => setSelectedSize("L")}
           />
-          <span className="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors">
-            L
-          </span>
+          <span className="size-selector">L</span>
         </label>
         <label className="cursor-pointer">
           <input
@@ -126,9 +120,7 @@ export default function CartInteraction({ product }: { product: Product }) {
             checked={selectedSize === "XL"}
             onChange={() => setSelectedSize("XL")}
           />
-          <span className="px-4 py-2 border rounded-md peer-checked:bg-blue-500 peer-checked:text-white transition-colors">
-            XL
-          </span>
+          <span className="size-selector">XL</span>
         </label>
       </div>
       <button

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -59,7 +59,7 @@ import heroBg from "../assets/hero_bg.png";
     class="absolute inset-y-0 right-0 w-full lg:w-[55%] hidden lg:block z-20"
   >
     <div
-      class="absolute top-[38%] left-[28%] flex items-center justify-center w-12 h-12 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm text-[var(--color-brand)] opacity-80 animate-pulse"
+      class="absolute top-[38%] left-[28%] hero-floating-icon"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -79,7 +79,7 @@ import heroBg from "../assets/hero_bg.png";
     </div>
 
     <div
-      class="absolute top-[24%] right-[10%] flex items-center justify-center w-12 h-12 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm text-[var(--color-brand)] opacity-80 animate-pulse"
+      class="absolute top-[24%] right-[10%] hero-floating-icon"
       style="animation-delay: 1s;"
     >
       <svg
@@ -99,7 +99,7 @@ import heroBg from "../assets/hero_bg.png";
     </div>
 
     <div
-      class="absolute bottom-[32%] right-[12%] flex items-center justify-center w-12 h-12 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm text-[var(--color-brand)] opacity-80 animate-pulse"
+      class="absolute bottom-[32%] right-[12%] hero-floating-icon"
       style="animation-delay: 2s;"
     >
       <svg

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,17 @@
   --font-display: "Playfair Display", serif;
 }
 
+@utility hero-floating-icon {
+  @apply flex items-center justify-center w-12 h-12 rounded-full
+         border border-white/10 bg-white/5 backdrop-blur-sm
+         text-[var(--color-brand)] opacity-80 animate-pulse;
+}
+
+@utility size-selector {
+  @apply px-4 py-2 border rounded-md transition-colors
+         peer-checked:bg-[var(--color-brand)] peer-checked:text-white;
+}
+
 :root {
   --color-bg: #0a1628;
   --color-brand: #f4541c;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,14 +6,11 @@
 }
 
 @utility hero-floating-icon {
-  @apply flex items-center justify-center w-12 h-12 rounded-full
-         border border-white/10 bg-white/5 backdrop-blur-sm
-         text-[var(--color-brand)] opacity-80 animate-pulse;
+  @apply flex items-center justify-center w-12 h-12 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm text-[var(--color-brand)] opacity-80 animate-pulse;
 }
 
 @utility size-selector {
-  @apply px-4 py-2 border rounded-md transition-colors
-         peer-checked:bg-[var(--color-brand)] peer-checked:text-white;
+  @apply px-4 py-2 border rounded-md transition-colors peer-checked:bg-[var(--color-brand)] peer-checked:text-white;
 }
 
 :root {


### PR DESCRIPTION
## What changed?
* Added two `@utility` directives in `global.css`: `hero-floating-icon` (shared by 3 decorative icon badges) and `size-selector` (shared by 4 size radio buttons).
* Updated `Hero.astro` to replace the repeated 15-class string on all 3 floating icon `div`s with the new `hero-floating-icon` utility.
* Updated `CartInteraction.tsx` to replace the repeated 7-class string on all 4 size `span`s with the new `size-selector` utility.
* The `size-selector` utility replaces `peer-checked:bg-blue-500` with `peer-checked:bg-[var(--color-brand)]`, aligning the selected-state color with the brand design system.
* Added `.atl/skill-registry.md` documenting the project's coding standards, stack, and conventions.

## Why?
* Long, duplicated Tailwind class strings ("chorizos") reduce readability and violate DRY. Extracting them into `@utility` keeps the markup clean while preserving Tailwind's purging, ordering, and variant support.
* The size selector was using `bg-blue-500`, a color outside the brand palette (`--color-brand` is orange/amber). This fix enforces design token consistency.
* Closes #N/A.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to the home page and verify the 3 floating icons on the Hero section (fire, thermometer, snowflake) still render as pulsing circles with the brand orange color.
3. Navigate to any product detail page and verify the size selectors (S, M, L, XL) display correctly. Select one and confirm the active state is now orange instead of blue.
4. Run `pnpm lint --write` and confirm no linting errors.
