### PR TITLE
fix(cart): add guard clause to removeItemFromCart to prevent crash

### DIFF
--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -78,11 +78,14 @@ export function clearCart() {
 
 export function removeItemFromCart(cartItemId: string) {
   const newCart = { ...cartItems.get() };
+  const item = newCart[cartItemId];
 
-  if (newCart[cartItemId].quantity > 1) {
+  if (!item) return;
+
+  if (item.quantity > 1) {
     newCart[cartItemId] = {
-      ...newCart[cartItemId],
-      quantity: newCart[cartItemId].quantity - 1,
+      ...item,
+      quantity: item.quantity - 1,
     };
   } else {
     delete newCart[cartItemId];


### PR DESCRIPTION
## What changed?
* Updated `src/store/cartStore.ts` to include an early return guard clause in the `removeItemFromCart` function.
* Refactored the function to safely extract the cart item first and prevent attempting to read `.quantity` from `undefined`.

## Why?
* This change prevents a critical `TypeError` that crashes the entire application if `removeItemFromCart` receives a `cartItemId` that doesn't exist in the current store state (e.g., due to race conditions, rapid double-clicking, or stale cached data).
* Closes #59 

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Add any item to the shopping cart.
3. Rapidly click the remove button multiple times, or artificially trigger `removeItemFromCart` with a non-existent ID via the console.
4. Verify that the application does not crash and the error is silently caught by the guard clause.
