### PR TITLE
feat(ui): style product detail view and enable whatsapp checkout

### DIFF
--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -29,7 +29,7 @@ const { product, wppUrl } = Astro.props;
 <section class="grid grid-cols-1 md:grid-cols-2 gap-3">
   <img src={product.image} alt={product.name} />
   <div>
-    <h1 class="text-2xl font-bold text-blue-400">{product.name}</h1>
+    <h1 class="text-2xl font-bold text-[var(--color-brand)]">{product.name}</h1>
     <span>${product.price}</span>
     <div>
       <div>
@@ -37,11 +37,11 @@ const { product, wppUrl } = Astro.props;
         <p class="underline py-2">(?) Ver Guía de Talles</p>
       </div>
       <p>{product?.description}</p>
-      <!-- <a
+      <a
         href={wppUrl}
         target="_blank"
         rel="noopener noreferrer"
-        class="flex items-center justify-center gap-2 text-center cursor-pointer bg-orange-400 p-2 my-2 rounded-lg w-90 text-slate-800 font-bold"
+        class="flex items-center justify-center gap-2 text-center cursor-pointer bg-[var(--color-brand)] p-2 my-2 rounded-lg w-90 text-[var(--color-bg)] font-bold"
         ><svg
           class="w-5 h-5"
           role="img"
@@ -51,7 +51,7 @@ const { product, wppUrl } = Astro.props;
             d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"
           ></path></svg
         >Enviar un mensaje por WhatsApp</a
-      > -->
+      >
     </div>
   </div>
 </section>


### PR DESCRIPTION
## What changed?
* Updated `src/components/ProductDetailView.astro` to use the global design system variable `--color-brand` for the product title instead of a hardcoded utility class.
* Uncommented the WhatsApp checkout anchor tag to enable the purchase flow.
* Styled the WhatsApp button using `--color-brand` and `--color-bg` to ensure contrast and brand consistency.

## Why?
* This change unblocks the main conversion flow by allowing users to complete purchases via WhatsApp with a pre-filled message.
* Removes hardcoded colors, ensuring the component adheres to the global design system.
* Closes #60.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to a product detail page.
3. Verify that the product title and WhatsApp button display the correct brand colors.
4. Click the "Enviar un mensaje por WhatsApp" button and ensure it opens the correct WhatsApp link with the dynamically generated URL.