### PR TITLE
refactor(ui): optimize remote images using Astro assets

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,13 @@
-// @ts-check
-
 import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
-// https://astro.build/config
 export default defineConfig({
   integrations: [react()],
+
+  image: {
+    domains: ["images.unsplash.com"],
+  },
 
   vite: {
     plugins: [tailwindcss()],

--- a/src/components/ProductCard.astro
+++ b/src/components/ProductCard.astro
@@ -1,4 +1,6 @@
 ---
+import { Image } from "astro:assets";
+
 interface Props {
   name: string;
   price: number;
@@ -22,9 +24,11 @@ const formattedPrice = new Intl.NumberFormat("es-AR", {
     href={`/products/${slug}`}
     class="block relative overflow-hidden aspect-[3/4]"
   >
-    <img
+    <Image
       src={image}
       alt={name}
+      inferSize={true}
+      format="webp"
       class="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.06]"
     />
     <div

--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from "astro:assets";
 import type { Product } from "../data/products.ts";
 import CartInteraction from "./CartInteraction";
 
@@ -27,7 +28,12 @@ const { product, wppUrl } = Astro.props;
   Volver al Inicio</a
 >
 <section class="grid grid-cols-1 md:grid-cols-2 gap-3">
-  <img src={product.image} alt={product.name} />
+  <Image
+    src={product.image}
+    alt={product.name}
+    inferSize={true}
+    format="webp"
+  />
   <div>
     <h1 class="text-2xl font-bold text-[var(--color-brand)]">{product.name}</h1>
     <span>${product.price}</span>


### PR DESCRIPTION
## What changed?
* Replaced standard HTML `<img>` tags with Astro's native `<Image />` component in `ProductCard.astro`.
* Replaced standard HTML `<img>` tags with Astro's native `<Image />` component in `ProductDetailView.astro`.
* Added `inferSize={true}` to automatically resolve dimensions for remote Unsplash images during the build step.
* Added `format="webp"` to enforce modern image compression.

## Why?
* Standard HTML `<img>` tags load raw, unoptimized images, significantly degrading performance on mobile networks. Astro's `<Image />` component automatically resizes and compresses them to modern formats (WebP), drastically improving Core Web Vitals and load times.
* Closes #39.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to the home page or catalog and inspect the product card images.
3. Verify that the image source is now served through Astro's optimized proxy (`/_image?...`) instead of the raw Unsplash URL.
4. Navigate to a product detail page and verify the same for the main product image.
5. Check the browser's Network tab to confirm the images are being served in `webp` format and have a reduced payload size.
