### PR TITLE
fix(cart): resolve React hydration mismatch in CartDrawer and CartIcon

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -1,4 +1,5 @@
 import { useStore } from "@nanostores/react";
+import { useEffect, useState } from "react";
 import {
   cartItems,
   clearCart,
@@ -11,8 +12,13 @@ import Drawer from "./Drawer";
 export default function CartDrawer() {
   const $isCartOpen = useStore(isCartOpen);
   const $cartItems = useStore(cartItems);
+  const [mounted, setMounted] = useState(false);
 
   const isNotEmpty = Object.keys($cartItems).length > 0;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <Drawer
@@ -49,54 +55,56 @@ export default function CartDrawer() {
             </svg>
           </button>
         </div>
-        <ul className="flex-grow overflow-y-auto my-4 pr-1">
-          {Object.values($cartItems).map((item) => (
-            <li
-              key={`${item.id}-${item.size}`}
-              className="flex items-center justify-between py-4 border-b border-[var(--color-border)]"
-            >
-              <div className="flex flex-col gap-1">
-                <span>
-                  {item.quantity} x {item.name} -{" "}
-                  <span className="font-semibold">${item.price}</span>
-                </span>
-                <span className="text-xs text-slate-400">
-                  Talle: {item.size} | Color: {item.color}
-                </span>
-              </div>
-
-              <button
-                type="button"
-                title="Close"
-                onClick={() =>
-                  removeItemFromCart(`${item.id}-${item.size}-${item.color}`)
-                }
+        {mounted && isNotEmpty && (
+          <ul className="flex-grow overflow-y-auto my-4 pr-1">
+            {Object.values($cartItems).map((item) => (
+              <li
+                key={`${item.id}-${item.size}`}
+                className="flex items-center justify-between py-4 border-b border-[var(--color-border)]"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.75"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="text-slate-400 hover:text-red-500 transition-colors cursor-pointer"
+                <div className="flex flex-col gap-1">
+                  <span>
+                    {item.quantity} x {item.name} -{" "}
+                    <span className="font-semibold">${item.price}</span>
+                  </span>
+                  <span className="text-xs text-slate-400">
+                    Talle: {item.size} | Color: {item.color}
+                  </span>
+                </div>
+
+                <button
+                  type="button"
+                  title="Close"
+                  onClick={() =>
+                    removeItemFromCart(`${item.id}-${item.size}-${item.color}`)
+                  }
                 >
-                  <title>Borrar producto del carrito</title>
-                  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                  <path d="M4 7l16 0" />
-                  <path d="M10 11l0 6" />
-                  <path d="M14 11l0 6" />
-                  <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12" />
-                  <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" />
-                </svg>
-              </button>
-            </li>
-          ))}
-        </ul>
-        {isNotEmpty ? (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="text-slate-400 hover:text-red-500 transition-colors cursor-pointer"
+                  >
+                    <title>Borrar producto del carrito</title>
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                    <path d="M4 7l16 0" />
+                    <path d="M10 11l0 6" />
+                    <path d="M14 11l0 6" />
+                    <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12" />
+                    <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" />
+                  </svg>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {mounted && isNotEmpty ? (
           <div className="mt-auto flex flex-col gap-3">
             <button
               type="button"

--- a/src/components/CartIcon.tsx
+++ b/src/components/CartIcon.tsx
@@ -1,5 +1,5 @@
 import { useStore } from "@nanostores/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cartItems, toggleCart } from "../store/cartStore";
 
 export default function CartIcon() {
@@ -16,8 +16,17 @@ export default function CartIcon() {
     0,
   );
 
+  const isFirstRender = useRef(true);
+  const prevTotalItems = useRef(totalItems);
+
   useEffect(() => {
-    if (totalItems > 0) {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      prevTotalItems.current = totalItems;
+      return;
+    }
+
+    if (totalItems > prevTotalItems.current) {
       setAnimate(true);
       const animateCart = setTimeout(() => {
         setAnimate(false);
@@ -26,6 +35,8 @@ export default function CartIcon() {
         clearTimeout(animateCart);
       };
     }
+
+    prevTotalItems.current = totalItems;
   }, [totalItems]);
 
   return (


### PR DESCRIPTION
## What changed?
* Updated `src/components/CartDrawer.tsx` by introducing a `mounted` state guard inside a `useEffect` hook. Conditionalized both the `<ul>` product list and the action buttons wrapper so they are hidden on the server and initial client paint, aligning server-side rendering (SSR) and client-side HTML output.
* Updated `src/components/CartIcon.tsx` by using `useRef` to track `isFirstRender` and `prevTotalItems`. Modified the animation effect to skip the bounce transition on initial page mount and ensure the scale effect is only triggered when the cart quantity increases.

## Why?
* Accessing `localStorage` via Nanostores on client hydration causes a DOM mismatch with Astro's empty-cart SSR output, leading to console errors. Delaying the rendering of client-dependent elements until the component is mounted fixes the mismatch.
* This conditional rendering also resolves a layout shift where an empty `<ul>` container with `flex-grow` was pushing the empty-state message down in `CartDrawer.tsx`.
* The cart badge animation was firing on every page load or refresh because the count transition from SSR (0) to stored client quantity was treated as a change. Using refs ensures animations are skipped on initial load and only trigger when items are added.
* Closes #77.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Add products to the cart and refresh the browser.
3. Verify that no "React hydration mismatch" error appears in the developer console.
4. Check that the cart icon badge does not perform a bounce animation on page reload.
5. Add another product to the cart and verify that the bounce animation plays.
6. Delete a product from the cart or empty the cart, and verify that the bounce animation does not play.
7. Empty the cart and confirm the "Tu carrito está vacío" text is centered vertically in the drawer.