### PR TITLE
fix(cart): resolve mobile layout and horizontal overflow in CartInteraction

### DIFF
--- a/src/components/CartInteraction.tsx
+++ b/src/components/CartInteraction.tsx
@@ -29,7 +29,7 @@ export default function CartInteraction({ product }: { product: Product }) {
   };
 
   return (
-    <div className="flex gap-2 py-2">
+    <div className="flex flex-col gap-4 py-2 w-full">
       <div>
         <h2>Color:</h2>
         <p>{selectedColor}</p>
@@ -74,58 +74,60 @@ export default function CartInteraction({ product }: { product: Product }) {
       </div>
       <div>
         <h2>Seleccioná tu Talle:</h2>
-        <label className="cursor-pointer">
-          <input
-            type="radio"
-            name={`size-${product.id}`}
-            id={`size-s-${product.id}`}
-            value="s"
-            className="sr-only peer"
-            checked={selectedSize === "S"}
-            onChange={() => setSelectedSize("S")}
-          />
-          <span className="size-selector">S</span>
-        </label>
-        <label className="cursor-pointer">
-          <input
-            type="radio"
-            name={`size-${product.id}`}
-            id={`size-m-${product.id}`}
-            value="m"
-            className="sr-only peer"
-            checked={selectedSize === "M"}
-            onChange={() => setSelectedSize("M")}
-          />
-          <span className="size-selector">M</span>
-        </label>
-        <label className="cursor-pointer">
-          <input
-            type="radio"
-            name={`size-${product.id}`}
-            id={`size-l-${product.id}`}
-            value="l"
-            className="sr-only peer"
-            checked={selectedSize === "L"}
-            onChange={() => setSelectedSize("L")}
-          />
-          <span className="size-selector">L</span>
-        </label>
-        <label className="cursor-pointer">
-          <input
-            type="radio"
-            name={`size-${product.id}`}
-            id={`size-xl-${product.id}`}
-            value="xl"
-            className="sr-only peer"
-            checked={selectedSize === "XL"}
-            onChange={() => setSelectedSize("XL")}
-          />
-          <span className="size-selector">XL</span>
-        </label>
+        <div className="flex gap-2 py-2">
+          <label className="cursor-pointer">
+            <input
+              type="radio"
+              name={`size-${product.id}`}
+              id={`size-s-${product.id}`}
+              value="s"
+              className="sr-only peer"
+              checked={selectedSize === "S"}
+              onChange={() => setSelectedSize("S")}
+            />
+            <span className="size-selector">S</span>
+          </label>
+          <label className="cursor-pointer">
+            <input
+              type="radio"
+              name={`size-${product.id}`}
+              id={`size-m-${product.id}`}
+              value="m"
+              className="sr-only peer"
+              checked={selectedSize === "M"}
+              onChange={() => setSelectedSize("M")}
+            />
+            <span className="size-selector">M</span>
+          </label>
+          <label className="cursor-pointer">
+            <input
+              type="radio"
+              name={`size-${product.id}`}
+              id={`size-l-${product.id}`}
+              value="l"
+              className="sr-only peer"
+              checked={selectedSize === "L"}
+              onChange={() => setSelectedSize("L")}
+            />
+            <span className="size-selector">L</span>
+          </label>
+          <label className="cursor-pointer">
+            <input
+              type="radio"
+              name={`size-${product.id}`}
+              id={`size-xl-${product.id}`}
+              value="xl"
+              className="sr-only peer"
+              checked={selectedSize === "XL"}
+              onChange={() => setSelectedSize("XL")}
+            />
+            <span className="size-selector">XL</span>
+          </label>
+        </div>
       </div>
       <button
         type="button"
-        className={`flex items-center justify-center gap-2 text-center cursor-pointer p-2 my-2 rounded-lg w-90 text-slate-800 font-bold transition-colors duration-300 ${isAdded ? "bg-emerald-500" : "bg-orange-400"}`}
+        className={`flex items-center justify-center gap-2 text-center cursor-pointer p-2 my-2 rounded-lg w-full max-w-sm text-slate-800 font-bold transition-colors duration-300 ${isAdded ? "bg-emerald-500" : "bg-orange-400"}`}
         onClick={handleAddToCart}
         disabled={isAdded}
       >

--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -11,53 +11,57 @@ interface Props {
 const { product, wppUrl } = Astro.props;
 ---
 
-<a href="/" class="flex underline gap-2"
-  ><svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke-width={1.5}
-    stroke="currentColor"
-    class="size-6"
+<div class="max-w-screen-xl mx-auto px-6 py-10 md:py-20">
+  <a href="/" class="flex underline gap-2"
+    ><svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width={1.5}
+      stroke="currentColor"
+      class="size-6"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M6.75 15.75 3 12m0 0 3.75-3.75M3 12h18"></path>
+    </svg>
+    Volver al Inicio</a
   >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M6.75 15.75 3 12m0 0 3.75-3.75M3 12h18"></path>
-  </svg>
-  Volver al Inicio</a
->
-<section class="grid grid-cols-1 md:grid-cols-2 gap-3">
-  <Image
-    src={product.image}
-    alt={product.name}
-    inferSize={true}
-    format="webp"
-  />
-  <div>
-    <h1 class="text-2xl font-bold text-[var(--color-brand)]">{product.name}</h1>
-    <span>${product.price}</span>
+  <section class="grid grid-cols-1 md:grid-cols-2 gap-3">
+    <Image
+      src={product.image}
+      alt={product.name}
+      inferSize={true}
+      format="webp"
+    />
     <div>
+      <h1 class="text-2xl font-bold text-[var(--color-brand)]">
+        {product.name}
+      </h1>
+      <span>${product.price}</span>
       <div>
-        <CartInteraction product={product} client:load />
-        <p class="underline py-2">(?) Ver Guía de Talles</p>
+        <div>
+          <CartInteraction product={product} client:load />
+          <p class="underline py-2">(?) Ver Guía de Talles</p>
+        </div>
+        <p>{product?.description}</p>
+        <a
+          href={wppUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center justify-center gap-2 text-center cursor-pointer bg-[var(--color-brand)] p-2 my-2 rounded-lg w-full max-w-sm text-[var(--color-bg)] font-bold"
+          ><svg
+            class="w-5 h-5"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            ><title>WhatsApp</title><path
+              d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"
+            ></path></svg
+          >Enviar un mensaje por WhatsApp</a
+        >
       </div>
-      <p>{product?.description}</p>
-      <a
-        href={wppUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="flex items-center justify-center gap-2 text-center cursor-pointer bg-[var(--color-brand)] p-2 my-2 rounded-lg w-90 text-[var(--color-bg)] font-bold"
-        ><svg
-          class="w-5 h-5"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-          ><title>WhatsApp</title><path
-            d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"
-          ></path></svg
-        >Enviar un mensaje por WhatsApp</a
-      >
     </div>
-  </div>
-</section>
+  </section>
+</div>


### PR DESCRIPTION
## What changed?
* Updated `src/components/CartInteraction.tsx` to display color, size, and cart action sections vertically by switching the main container to `flex-col gap-4 w-full`. Wrapped the size labels in a flex container for equal horizontal spacing, and updated the checkout button width class from a fixed `w-90` to a fluid `w-full max-w-sm`.
* Updated `src/components/ProductDetailView.astro` by wrapping the entire page content in a structured layout container with responsive padding and a max-width wrapper (`max-w-screen-xl mx-auto px-6 py-10 md:py-20`). Also converted the WhatsApp checkout button from a fixed `w-90` width to a responsive `w-full max-w-sm`.

## Why?
* The options layout was previously set to `flex-row`, squeezing elements horizontally and causing text/icons to break and overflow on mobile viewports.
* Sizing the buttons with a hardcoded `w-90` width (360px) caused them to overflow smaller devices (like iPhone SE at 320px). Switching to `w-full max-w-sm` ensures they scale down gracefully.
* Lacking a page-level container made all details and the back navigation link touch the absolute edges of the screen. Putting them in a common wrapper guarantees alignment and visual consistency across all viewports.
* Closes #78.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to a product detail page (e.g., `/products/buzo-termico-de-primera-piel`).
3. Toggle mobile emulation in your browser dev tools (e.g., iPhone SE mode).
4. Verify that the layout does not produce a horizontal scrollbar.
5. Verify that the back link and product content have consistent margins on the left and right sides.
6. Verify that both the "Añadir al Carrito" and "Enviar un mensaje por WhatsApp" buttons shrink to fit the mobile screen width and align perfectly.
