### PR TITLE
perf(navbar): optimize hydration for CartIcon and MobileMenu

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -37,11 +37,11 @@ import MobileMenu from "./MobileMenu";
 
       <span class="hidden md:inline h-4 w-px bg-[var(--color-border)]"></span>
 
-      <CartIcon client:load />
+      <CartIcon client:idle />
 
       <span class="h-4 w-px bg-[var(--color-border)] md:hidden"></span>
 
-      <MobileMenu client:load>
+      <MobileMenu client:media="(max-width: 767px)">
         <a
           href="/"
           class="mobile-nav-link text-slate-300 hover:text-white transition-all duration-200 py-3 px-2 rounded-lg hover:bg-white/5 border-b border-white/[0.03] flex items-center justify-between group"


### PR DESCRIPTION
## What changed?
* Updated `src/components/Navbar.astro` to optimize React components hydration:
  - Defer hydration of `CartIcon` by switching from `client:load` to `client:idle`.
  - Restrict `MobileMenu` hydration to mobile screen sizes by switching from `client:load` to `client:media="(max-width: 767px)"`.

## Why?
* Prevents loading mobile menu JS on desktop viewports, reducing initial JS bundle size and saving network/CPU resources.
* Defers the hydration of the cart icon until the main thread is idle, improving First Input Delay (FID) and First Contentful Paint (FCP).

## How to test
1. Run the development server (`pnpm run dev`).
2. Open the website on desktop and check the Network/JS tab to ensure the `MobileMenu` component script is not requested.
3. Switch the viewport to mobile width (<768px) and verify that the menu script loads and functions correctly.
4. Verify that the cart opens as expected on click.
