### PR TITLE
feat(detail): implement accessible sizing guide modal

### DIFF
--- a/src/components/CartInteraction.tsx
+++ b/src/components/CartInteraction.tsx
@@ -1,11 +1,40 @@
 import { useState } from "react";
 import type { Product } from "../data/products";
 import { addItemsToCart } from "../store/cartStore";
+import Modal from "./Modal";
+
+const SIZE_CHART = [
+  {
+    name: "S",
+    chest: "88 - 94",
+    waist: "76 - 82",
+    hip: "88 - 94",
+  },
+  {
+    name: "M",
+    chest: "95 - 101",
+    waist: "83 - 89",
+    hip: "95 - 101",
+  },
+  {
+    name: "L",
+    chest: "102 - 108",
+    waist: "90 - 96",
+    hip: "102 - 108",
+  },
+  {
+    name: "XL",
+    chest: "109 - 115",
+    waist: "97 - 103",
+    hip: "109 - 115",
+  },
+];
 
 export default function CartInteraction({ product }: { product: Product }) {
   const [selectedSize, setSelectedSize] = useState("S");
   const [selectedColor, setSelectedColor] = useState("Slate");
   const [isAdded, setIsAdded] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleAddToCart = () => {
     const itemToBeAdded = {
@@ -72,6 +101,7 @@ export default function CartInteraction({ product }: { product: Product }) {
           </label>
         </div>
       </div>
+
       <div>
         <h2>Seleccioná tu Talle:</h2>
         <div className="flex gap-2 py-2">
@@ -124,7 +154,16 @@ export default function CartInteraction({ product }: { product: Product }) {
             <span className="size-selector">XL</span>
           </label>
         </div>
+
+        <button
+          type="button"
+          className="text-[var(--color-brand)] underline cursor-pointer mt-3 inline-block hover:text-orange-400 transition-colors"
+          onClick={() => setIsModalOpen(true)}
+        >
+          Abrir Guía de Talles
+        </button>
       </div>
+
       <button
         type="button"
         className={`flex items-center justify-center gap-2 text-center cursor-pointer p-2 my-2 rounded-lg w-full max-w-sm text-slate-800 font-bold transition-colors duration-300 ${isAdded ? "bg-emerald-500" : "bg-orange-400"}`}
@@ -133,6 +172,109 @@ export default function CartInteraction({ product }: { product: Product }) {
       >
         {isAdded ? "¡Añadido!" : "Añadir al Carrito"}
       </button>
+
+      <Modal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        ariaLabel="Guía de Talles"
+      >
+        <div>
+          <div className="flex justify-between items-center mb-6">
+            <h2 className="font-semibold uppercase tracking-wider text-[var(--color-brand)]">
+              Guía de Talles
+            </h2>
+
+            <button
+              type="button"
+              onClick={() => setIsModalOpen(false)}
+              className="p-2 hover:bg-white/10 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 cursor-pointer"
+              aria-label="Cerrar guía de talles"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.75"
+                aria-labelledby="title"
+                className="icon icon-tabler icons-tabler-outline icon-tabler-x cursor-pointer"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <title>Cerrar Guía de Talles</title>
+                <path fill="none" stroke="none" d="M0 0h24v24H0z" />
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <table className="w-full border-collapse mt-6 text-left text-sm">
+            <thead>
+              <tr>
+                <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
+                  Talle
+                </th>
+                <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
+                  Pecho (cm)
+                </th>
+                <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
+                  Cintura (cm)
+                </th>
+                <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
+                  Cadera (cm)
+                </th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {SIZE_CHART.map((row) => (
+                <tr
+                  key={row.name}
+                  className="hover:bg-white/5 transition-colors"
+                >
+                  <td className="py-3 border-b border-white/5 text-slate-400">
+                    {row.name}
+                  </td>
+                  <td className="py-3 border-b border-white/5 text-slate-400">
+                    {row.chest}
+                  </td>
+                  <td className="py-3 border-b border-white/5 text-slate-400">
+                    {row.waist}
+                  </td>
+                  <td className="py-3 border-b border-white/5 text-slate-400">
+                    {row.hip}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mt-6 pt-6 border-t border-white/10">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--color-brand)] mb-3">
+              Cómo tomar mis medidas para saber mi talle
+            </h3>
+            <ul className="text-sm text-slate-400 leading-relaxed">
+              <li>
+                <span className="font-semibold text-slate-300">Pecho:</span>{" "}
+                Medí la parte más ancha del pecho, manteniendo la cinta métrica
+                horizontal y floja.
+              </li>
+              <li>
+                <span className="font-semibold text-slate-300">Cintura:</span>{" "}
+                Medí alrededor de la parte más angosta de la cintura (justo
+                encima del ombligo.
+              </li>
+              <li>
+                <span className="font-semibold text-slate-300">Cadera:</span>{" "}
+                Con los pies juntos, medí la parte más ancha de la cadera.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode, useEffect, useRef } from "react";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  ariaLabel?: string;
+}
+
+export default function Modal({ isOpen, onClose, children, ariaLabel }: Props) {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const modal = modalRef.current;
+
+    if (isOpen) {
+      modal?.showModal();
+    } else {
+      modal?.close();
+    }
+  }, [isOpen]);
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: El elemento dialog maneja el escape nativamente
+    <dialog
+      ref={modalRef}
+      aria-label={ariaLabel}
+      className="fixed inset-0 m-auto max-w-lg w-[calc(100%-2rem)] backdrop:bg-black/60 bg-[var(--color-bg)] rounded-xl p-6 shadow-2xl text-white focus:outline-none backdrop:backdrop-blur-sm"
+      onClose={() => onClose()}
+      onClick={(e) => {
+        if (e.target === modalRef.current) {
+          onClose();
+        }
+      }}
+    >
+      <div>{children}</div>
+    </dialog>
+  );
+}

--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -43,7 +43,6 @@ const { product, wppUrl } = Astro.props;
       <div>
         <div>
           <CartInteraction product={product} client:load />
-          <p class="underline py-2">(?) Ver Guía de Talles</p>
         </div>
         <p>{product?.description}</p>
         <a


### PR DESCRIPTION
## What changed?
* Created a reusable `Modal.tsx` component utilizing the native HTML5 `<dialog>` element.
* Integrated the sizing guide modal in `CartInteraction.tsx` to handle size selection dynamically with `useState`.
* Embedded the size chart table and body measurement instructions inside `CartInteraction.tsx`.
* Cleaned up the redundant static size guide trigger in `ProductDetailView.astro`.

## Why?
* Resolved accessibility issues (focus trapping, focus restoration, and Escape-key closing) on the sizing guide.
* Improved user experience by providing standard body measurement guides on details page.
* Closes #84.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to any product details page.
3. Click on the "Abrir Guía de Talles" link.
4. Verify the modal opens centered with the dark theme styling.
5. Verify keyboard Tab key navigation traps focus inside the modal.
6. Verify pressing Escape or clicking the close "X" button closes the modal and returns focus to the trigger link.

