### PR TITLE
fix(cart): resolve React key collision in CartDrawer items

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -60,7 +60,7 @@ export default function CartDrawer() {
           <ul className="flex-grow overflow-y-auto my-4 pr-1">
             {Object.values($cartItems).map((item) => (
               <li
-                key={`${item.id}-${item.size}`}
+                key={`${item.id}-${item.size}-${item.color}`}
                 className="flex items-center justify-between py-4 border-b border-[var(--color-border)]"
               >
                 <div className="flex flex-col gap-1">


### PR DESCRIPTION
## What changed?
* Updated `src/components/CartDrawer.tsx` to use a composite iteration key containing the product ID, size, and color.

## Why?
* Prevents React duplicate key warnings and rendering bugs when purchasing the same product in multiple colors of the same size.
* Closes #91.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Add the same product in the same size but with different colors to the cart.
3. Open the cart drawer and delete one of the color variants.
4. Verify that the correct item is removed from the DOM and no duplicate key warnings appear in the console.

