### PR TITLE
refactor(cart): rename addItemsToCart to addItemToCart and support dynamic quantity

### DIFF
--- a/src/components/CartInteraction.tsx
+++ b/src/components/CartInteraction.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Product } from "../data/products";
-import { addItemsToCart } from "../store/cartStore";
+import { addItemToCart } from "../store/cartStore";
 import Modal from "./Modal";
 
 const SIZE_CHART = [
@@ -51,7 +51,7 @@ export default function CartInteraction({ product }: { product: Product }) {
       quantity: 1,
     };
 
-    addItemsToCart(itemToBeAdded);
+    addItemToCart(itemToBeAdded);
 
     setIsAdded(true);
 

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -27,7 +27,7 @@ export const cartItems = persistentAtom<Record<string, CartItem>>(
   },
 );
 
-export function addItemsToCart(item: CartItem) {
+export function addItemToCart(item: CartItem) {
   const cartItemId = `${item.id}-${item.size}-${item.color}`;
 
   const existingItem = cartItems.get()[cartItemId];
@@ -35,12 +35,15 @@ export function addItemsToCart(item: CartItem) {
   if (existingItem) {
     cartItems.set({
       ...cartItems.get(),
-      [cartItemId]: { ...existingItem, quantity: existingItem.quantity + 1 },
+      [cartItemId]: {
+        ...existingItem,
+        quantity: existingItem.quantity + item.quantity,
+      },
     });
   } else {
     cartItems.set({
       ...cartItems.get(),
-      [cartItemId]: { ...item, quantity: 1 },
+      [cartItemId]: { ...item, quantity: item.quantity },
     });
   }
   const newToast: Toast = {


### PR DESCRIPTION
## What changed?
* Renamed `addItemsToCart` to `addItemToCart` in `cartStore.ts` and `CartInteraction.tsx` to make it semantically singular.
* Updated `addItemToCart` in `cartStore.ts` to use `item.quantity` instead of hardcoded `1` and `+ 1` increments.

## Why?
* This change ensures that the cart store respects the quantity of items being added, laying the groundwork for a future quantity selector in the UI.
* Closes #97.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to any product detail page.
3. Click the "Añadir al carrito" button.
4. Verify that the product is added to the cart and the cart drawer opens, showing the product with the correct quantity (1 by default).

