### PR TITLE
style(catalog): add tablet breakpoint to product grid

### DIFF
--- a/src/components/ProductGrid.astro
+++ b/src/components/ProductGrid.astro
@@ -25,7 +25,7 @@ import ProductCard from "./ProductCard.astro";
       </span>
     </div>
 
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6">
+    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 md:gap-6">
       {
         products.map((product) => (
           <ProductCard


### PR DESCRIPTION
## What changed?
* Updated `ProductGrid.astro` to include the `sm:grid-cols-3` class on the product grid container.

## Why?
* This prevents the product catalog grid from jumping abruptly from 2 columns on mobile directly to 4 columns on desktop, providing a balanced 3-column layout on tablet-sized viewports.
* Closes #96.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to the home page or catalog grid.
3. Resize the viewport to a tablet width (between 640px and 768px).
4. Verify that the product grid displays exactly 3 columns and fits the screen nicely.

