### PR TITLE
fix(a11y): prevent invisible focus navigation on closed mobile menu

### DIFF
--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -46,6 +46,7 @@ export default function MobileMenu({ children }: MobileMenuProps) {
         className={`fixed top-0 right-0 w-72 h-screen z-50 bg-[#0a1628] border-l border-[var(--color-border)] shadow-2xl transition-transform duration-300 ease-in-out flex flex-col ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
+        inert={!isOpen}
       >
         <div className="flex justify-end items-center h-16 px-6 border-b border-white/[0.03]">
           <button


### PR DESCRIPTION
## What changed?
* Updated `src/components/MobileMenu.tsx` to pass the boolean `!isOpen` directly to the `inert` attribute.

## Why?
* Prevents keyboard users from navigating to invisible links when the mobile menu is closed.
* Closes #87.

## How to test
1. Ensure the development server is running (`pnpm dev`).
2. Press `Tab` repeatedly while the mobile menu is closed.
3. Verify that the focus indicator does not disappear into the hidden menu.

