### PR TITLE
refactor(theme): map CSS theme variables to Tailwind CSS v4 theme

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -25,7 +25,7 @@ export default function CartDrawer() {
     <Drawer
       isOpen={$isCartOpen}
       onClose={() => isCartOpen.set(false)}
-      className="w-full sm:max-w-md bg-[var(--color-bg)]"
+      className="w-full sm:max-w-md bg-bg"
       ariaLabel="Carrito de compras"
     >
       <div className="p-4 flex flex-col h-full text-white/80">
@@ -61,7 +61,7 @@ export default function CartDrawer() {
             {Object.values($cartItems).map((item) => (
               <li
                 key={`${item.id}-${item.size}-${item.color}`}
-                className="flex items-center justify-between py-4 border-b border-[var(--color-border)]"
+                className="flex items-center justify-between py-4 border-b border-border"
               >
                 <div className="flex flex-col gap-1">
                   <span>

--- a/src/components/CartInteraction.tsx
+++ b/src/components/CartInteraction.tsx
@@ -113,7 +113,7 @@ export default function CartInteraction({ product }: { product: Product }) {
 
         <button
           type="button"
-          className="text-[var(--color-brand)] underline cursor-pointer mt-3 inline-block hover:text-orange-400 transition-colors"
+          className="text-brand underline cursor-pointer mt-3 inline-block hover:text-orange-400 transition-colors"
           onClick={() => setIsModalOpen(true)}
         >
           Abrir Guía de Talles
@@ -136,7 +136,7 @@ export default function CartInteraction({ product }: { product: Product }) {
       >
         <div>
           <div className="flex justify-between items-center mb-6">
-            <h2 className="font-semibold uppercase tracking-wider text-[var(--color-brand)]">
+            <h2 className="font-semibold uppercase tracking-wider text-brand">
               Guía de Talles
             </h2>
 
@@ -209,7 +209,7 @@ export default function CartInteraction({ product }: { product: Product }) {
           </table>
 
           <div className="mt-6 pt-6 border-t border-white/10">
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--color-brand)] mb-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-brand mb-3">
               Cómo tomar mis medidas para saber mi talle
             </h3>
             <ul className="text-sm text-slate-400 leading-relaxed">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -36,7 +36,7 @@ const currentYear = new Date().getFullYear();
             ></path>
           </svg>
           <span>
-            <span class="font-extrabold text-[var(--color-brand)]"
+            <span class="font-extrabold text-brand"
               >Abrigate</span
             > Bien
           </span>
@@ -49,7 +49,7 @@ const currentYear = new Date().getFullYear();
 
       <div class="flex flex-col gap-4">
         <h3
-          class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--color-brand)]"
+          class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-brand"
         >
           Navegación
         </h3>
@@ -83,7 +83,7 @@ const currentYear = new Date().getFullYear();
 
       <div class="flex flex-col gap-4 md:items-end">
         <h3
-          class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--color-brand)]"
+          class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-brand"
         >
           Comunidad
         </h3>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -4,7 +4,7 @@ import heroBg from "../assets/hero_bg.png";
 ---
 
 <section
-  class="relative w-full min-h-screen bg-[var(--color-bg)] flex items-center overflow-hidden"
+  class="relative w-full min-h-screen bg-bg flex items-center overflow-hidden"
 >
   <div
     class="absolute inset-0 lg:inset-y-0 lg:left-auto lg:right-30 w-full lg:w-[55%] z-0"
@@ -16,9 +16,9 @@ import heroBg from "../assets/hero_bg.png";
       loading="eager"
       quality={95}
     />
-    <div class="absolute inset-0 bg-[var(--color-bg)]/80 lg:hidden"></div>
+    <div class="absolute inset-0 bg-bg/80 lg:hidden"></div>
     <div
-      class="absolute inset-0 bg-gradient-to-r from-[var(--color-bg)] via-transparent to-[var(--color-bg)] hidden lg:block"
+      class="absolute inset-0 bg-gradient-to-r from-bg via-transparent to-bg hidden lg:block"
     >
     </div>
   </div>
@@ -41,13 +41,13 @@ import heroBg from "../assets/hero_bg.png";
         >
           que te
         </span>
-        <span class="text-[var(--color-brand)]">abraza</span>
+        <span class="text-brand">abraza</span>
       </h1>
 
       <div class="mt-10">
         <a
           href="/catalog"
-          class="cursor-pointer bg-[var(--color-brand)] text-white font-semibold px-8 py-4 rounded-full transition-all duration-300 hover:scale-105 hover:shadow-[0_0_30px_rgba(244,84,28,0.5)] inline-block"
+          class="cursor-pointer bg-brand text-white font-semibold px-8 py-4 rounded-full transition-all duration-300 hover:scale-105 hover:shadow-[0_0_30px_rgba(244,84,28,0.5)] inline-block"
         >
           Explorar Colección
         </a>

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -43,7 +43,7 @@ export default function MobileMenu({ children }: MobileMenuProps) {
       />
 
       <div
-        className={`fixed top-0 right-0 w-72 h-screen z-50 bg-[#0a1628] border-l border-[var(--color-border)] shadow-2xl transition-transform duration-300 ease-in-out flex flex-col ${
+        className={`fixed top-0 right-0 w-72 h-screen z-50 bg-[#0a1628] border-l border-border shadow-2xl transition-transform duration-300 ease-in-out flex flex-col ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
         inert={!isOpen}
@@ -51,7 +51,7 @@ export default function MobileMenu({ children }: MobileMenuProps) {
         <div className="flex justify-end items-center h-16 px-6 border-b border-white/[0.03]">
           <button
             type="button"
-            className="text-white hover:text-[var(--color-brand)] transition-colors cursor-pointer flex items-center justify-center w-8 h-8"
+            className="text-white hover:text-brand transition-colors cursor-pointer flex items-center justify-center w-8 h-8"
             onClick={() => setIsOpen(false)}
             aria-label="Cerrar menú"
           >

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -25,7 +25,7 @@ export default function Modal({ isOpen, onClose, children, ariaLabel }: Props) {
     <dialog
       ref={modalRef}
       aria-label={ariaLabel}
-      className="fixed inset-0 m-auto max-w-lg w-[calc(100%-2rem)] backdrop:bg-black/60 bg-[var(--color-bg)] rounded-xl p-6 shadow-2xl text-white focus:outline-none backdrop:backdrop-blur-sm"
+      className="fixed inset-0 m-auto max-w-lg w-[calc(100%-2rem)] backdrop:bg-black/60 bg-bg rounded-xl p-6 shadow-2xl text-white focus:outline-none backdrop:backdrop-blur-sm"
       onClose={() => onClose()}
       onClick={(e) => {
         if (e.target === modalRef.current) {

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -4,7 +4,7 @@ import MobileMenu from "./MobileMenu";
 ---
 
 <nav
-  class="fixed top-0 left-0 w-full h-20 z-40 bg-[var(--color-navbar)] backdrop-blur-md border-b border-[var(--color-border)]"
+  class="fixed top-0 left-0 w-full h-20 z-40 bg-navbar backdrop-blur-md border-b border-border"
 >
   <div
     class="flex justify-between items-center px-6 h-full max-w-screen-xl mx-auto relative"
@@ -13,7 +13,7 @@ import MobileMenu from "./MobileMenu";
       href="/"
       class="font-sans text-xl tracking-wide text-white hover:opacity-90 transition-opacity duration-200"
     >
-      <span class="font-extrabold text-[var(--color-brand)]">Abrigate</span> Bien
+      <span class="font-extrabold text-brand">Abrigate</span> Bien
     </a>
 
     <div class="flex items-center gap-4 md:gap-6">
@@ -35,11 +35,11 @@ import MobileMenu from "./MobileMenu";
         >
       </div>
 
-      <span class="hidden md:inline h-4 w-px bg-[var(--color-border)]"></span>
+      <span class="hidden md:inline h-4 w-px bg-border"></span>
 
       <CartIcon client:idle />
 
-      <span class="h-4 w-px bg-[var(--color-border)] md:hidden"></span>
+      <span class="h-4 w-px bg-border md:hidden"></span>
 
       <MobileMenu client:media="(max-width: 767px)">
         <a
@@ -57,7 +57,7 @@ import MobileMenu from "./MobileMenu";
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
-            class="opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 text-[var(--color-brand)]"
+            class="opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 text-brand"
           >
             <path d="m9 18 6-6-6-6"></path>
           </svg>
@@ -77,7 +77,7 @@ import MobileMenu from "./MobileMenu";
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
-            class="opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 text-[var(--color-brand)]"
+            class="opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 text-brand"
           >
             <path d="m9 18 6-6-6-6"></path>
           </svg>
@@ -97,7 +97,7 @@ import MobileMenu from "./MobileMenu";
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"
-            class="opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 text-[var(--color-brand)]"
+            class="opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200 text-brand"
           >
             <path d="m9 18 6-6-6-6"></path>
           </svg>

--- a/src/components/ProductCard.astro
+++ b/src/components/ProductCard.astro
@@ -35,7 +35,7 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
       class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-400 ease-out flex flex-col justify-end p-5"
     >
       <span
-        class="block w-full text-center bg-[var(--color-brand)] text-white text-xs font-bold uppercase tracking-widest py-3 translate-y-4 group-hover:translate-y-0 transition-transform duration-400 ease-out"
+        class="block w-full text-center bg-brand text-white text-xs font-bold uppercase tracking-widest py-3 translate-y-4 group-hover:translate-y-0 transition-transform duration-400 ease-out"
       >
         Ver Detalles
       </span>
@@ -48,7 +48,7 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
     >
       {name}
     </h2>
-    <p class="font-sans text-[var(--color-brand)] font-bold text-sm mt-1">
+    <p class="font-sans text-brand font-bold text-sm mt-1">
       {formattedPrice}
     </p>
   </div>

--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -31,7 +31,7 @@ const { product, wppUrl } = Astro.props;
   <section class="grid grid-cols-1 md:grid-cols-2 gap-3">
     <Image src={product.image} alt={product.name} format="webp" />
     <div>
-      <h1 class="text-2xl font-bold text-[var(--color-brand)]">
+      <h1 class="text-2xl font-bold text-brand">
         {product.name}
       </h1>
       <div>
@@ -43,7 +43,7 @@ const { product, wppUrl } = Astro.props;
           href={wppUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="flex items-center justify-center gap-2 text-center cursor-pointer bg-[var(--color-brand)] p-2 my-2 rounded-lg w-full max-w-sm text-[var(--color-bg)] font-bold"
+          class="flex items-center justify-center gap-2 text-center cursor-pointer bg-brand p-2 my-2 rounded-lg w-full max-w-sm text-bg font-bold"
           ><svg
             class="w-5 h-5"
             role="img"

--- a/src/components/ProductGrid.astro
+++ b/src/components/ProductGrid.astro
@@ -8,7 +8,7 @@ import ProductCard from "./ProductCard.astro";
     <div class="flex items-end justify-between mb-10">
       <div>
         <p
-          class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--color-brand)] mb-2"
+          class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-brand mb-2"
         >
           Colección Técnica
         </p>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,7 +37,7 @@ const {
     <meta property="og:description" content={description} />
     <meta property="og:image" content={new URL(ogImage, Astro.url)} />
   </head>
-  <body class="flex flex-col min-h-screen">
+  <body class="flex flex-col min-h-screen text-body bg-bg">
     <Navbar />
     <CartDrawer client:load />
     <ToastContainer client:load />
@@ -54,8 +54,6 @@ const {
     margin: 0;
     width: 100%;
     height: 100%;
-    background-color: var(--color-bg);
-    color: var(--color-body);
     font-family: var(--font-sans);
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,21 +3,18 @@
 @theme {
   --font-sans: "Montserrat", ui-sans-serif, system-ui, sans-serif;
   --font-display: "Playfair Display", serif;
-}
-
-@utility hero-floating-icon {
-  @apply flex items-center justify-center w-12 h-12 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm text-[var(--color-brand)] opacity-80 animate-pulse;
-}
-
-@utility size-selector {
-  @apply px-4 py-2 border rounded-md transition-colors peer-checked:bg-[var(--color-brand)] peer-checked:text-white;
-}
-
-:root {
   --color-bg: #0a1628;
   --color-brand: #f4541c;
   --color-heading: #ffffff;
   --color-body: #94a3b8;
   --color-navbar: rgba(10, 22, 40, 0.75);
   --color-border: rgba(255, 255, 255, 0.08);
+}
+
+@utility hero-floating-icon {
+  @apply flex items-center justify-center w-12 h-12 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm text-brand opacity-80 animate-pulse;
+}
+
+@utility size-selector {
+  @apply px-4 py-2 border rounded-md transition-colors peer-checked:bg-brand peer-checked:text-white;
 }


### PR DESCRIPTION
## What changed?
* Moved color design tokens (e.g., `--color-brand`, `--color-bg`, `--color-border`) from the `:root` block to the `@theme` directive in `src/styles/global.css`.
* Refactored `src/layouts/Layout.astro` to use native Tailwind utility classes (`bg-bg` and `text-body`) on the `<body>` element and removed redundant CSS rules from the `<style>` block.
* Updated `src/components/Navbar.astro`, `src/components/Hero.astro`, `src/components/ProductCard.astro`, `src/components/ProductGrid.astro`, `src/components/ProductDetailView.astro`, and `src/components/Footer.astro` to replace manual variable references with native Tailwind utility classes.
* Updated `src/components/CartDrawer.tsx`, `src/components/CartInteraction.tsx`, `src/components/MobileMenu.tsx`, and `src/components/Modal.tsx` to replace manual variable references with native Tailwind utility classes.

## Why?
* Leverages Tailwind CSS v4 native CSS variable theme registration.
* Reduces verbosity by replacing arbitrary class mappings like `bg-[var(--color-bg)]` with clean utility classes like `bg-bg`.
* Closes #86.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Open the application in your browser.
3. Verify that the background colors, text colors, borders, and brand accents render correctly on all pages and components (including the Navbar, Hero, Product Grid, Product Detail View, Cart Drawer, and Footer).
