### PR TITLE
fix(cart): resolve WhatsApp checkout URL reactivity issue in CartDrawer

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -1,5 +1,5 @@
 import { useStore } from "@nanostores/react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   cartItems,
   clearCart,
@@ -13,7 +13,7 @@ export default function CartDrawer() {
   const $isCartOpen = useStore(isCartOpen);
   const $cartItems = useStore(cartItems);
   const [mounted, setMounted] = useState(false);
-  const wppUrl = getWhatsAppUrl();
+  const wppUrl = useMemo(() => getWhatsAppUrl($cartItems), [$cartItems]);
 
   const isNotEmpty = Object.keys($cartItems).length > 0;
 

--- a/src/store/cartStore.ts
+++ b/src/store/cartStore.ts
@@ -54,8 +54,8 @@ export function addItemToCart(item: CartItem) {
   toasts.set([...toasts.get(), newToast]);
 }
 
-export function getWhatsAppUrl() {
-  const items = Object.values(cartItems.get());
+export function getWhatsAppUrl(itemsMap: Record<string, CartItem>) {
+  const items = Object.values(itemsMap);
 
   if (items.length === 0) return null;
 


### PR DESCRIPTION
## What changed?
* Refactored `getWhatsAppUrl` in `src/store/cartStore.ts` to be a pure function by accepting the cart items map as a parameter instead of reading from the global store imperatively.
* Updated `CartDrawer.tsx` to compute `wppUrl` reactively by passing the reactive `$cartItems` state into `getWhatsAppUrl` inside a `useMemo` hook, ensuring the checkout link updates instantly on cart mutations.

## Why?
* Previously, the WhatsApp checkout link was computed at mount-time or without proper reactive tracking of `$cartItems` changes, resulting in a stale order message if items were added, modified, or removed.
* Closes #103.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Add one or more products to the shopping cart.
3. Verify that the WhatsApp checkout CTA URL contains the added items.
4. Add more items or modify quantities and verify that the URL is updated reactively in real time without refreshing the page.

