### PR TITLE
feat(product-detail): redesign page layout and typography

### DIFF
--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -9,9 +9,15 @@ interface Props {
 }
 
 const { product, wppUrl } = Astro.props;
+
+const formattedPrice = new Intl.NumberFormat("es-UY", {
+  style: "currency",
+  currency: "UYU",
+  maximumFractionDigits: 0,
+}).format(product.price);
 ---
 
-<div class="max-w-screen-xl mx-auto px-6 py-10 md:py-20">
+<div class="max-w-screen-xl mx-auto px-6 pt-24 pb-10 md:pt-32 md:pb-20">
   <a href="/" class="flex underline gap-2"
     ><svg
       xmlns="http://www.w3.org/2000/svg"
@@ -28,32 +34,36 @@ const { product, wppUrl } = Astro.props;
     </svg>
     Volver al Inicio</a
   >
-  <section class="grid grid-cols-1 md:grid-cols-2 gap-3">
-    <Image src={product.image} alt={product.name} format="webp" />
-    <div>
-      <h1 class="text-2xl font-bold text-brand">
+  <section class="grid grid-cols-1 md:grid-cols-12 gap-8 md:gap-12 items-start">
+    <div
+      class="md:col-span-7 overflow-hidden border border-white/5 bg-white/[0.02]"
+    >
+      <Image
+        src={product.image}
+        alt={product.name}
+        format="webp"
+        class={"hover:scale-[1.02] transition-transform duration-700 ease-out w-full aspect-[4/5] object-cover"}
+      />
+    </div>
+
+    <div class="md:col-span-5">
+      <span
+        class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-brand mb-2 block"
+        >Colección Técnica</span
+      >
+      <h1
+        class="font-display text-3xl md:text-4xl text-white tracking-tight leading-tight"
+      >
         {product.name}
       </h1>
-      <div>
-        <div>
-          <CartInteraction product={product} client:load />
-        </div>
-        <p>{product?.description}</p>
-        <a
-          href={wppUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="flex items-center justify-center gap-2 text-center cursor-pointer bg-brand p-2 my-2 rounded-lg w-full max-w-sm text-bg font-bold"
-          ><svg
-            class="w-5 h-5"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-            ><title>WhatsApp</title><path
-              d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"
-            ></path></svg
-          >Enviar un mensaje por WhatsApp</a
-        >
+      <p class="text-2xl font-semibold text-white mt-3">{formattedPrice}</p>
+
+      <div class="border-t border-white/10 pt-6 mt-6">
+        <p class="text-sm text-slate-400 leading-relaxed mb-6">{product.description}</p>
+      </div>
+
+      <div class="border-t border-white/10 pt-6 mt-6">
+        <CartInteraction product={product} client:load />
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What changed?
* Updated `src/components/ProductDetailView.astro`:
  * Modified page container padding (`pt-24 pb-10 md:pt-32 md:pb-20`) to prevent the fixed navigation bar from overlapping content on mobile and desktop screens.
  * Replaced the responsive layout with a `grid grid-cols-1 md:grid-cols-12` and generous gap spacing (`gap-8 md:gap-12 items-start`) to create a balanced 7:5 presentation.
  * Enclosed the main product image in a `md:col-span-7` column, applying flat borders (`border border-white/5 bg-white/[0.02]`), aspect-ratio clipping (`aspect-[4/5] object-cover`), and a smooth scale-up zoom transition on hover.
  * Placed purchase details inside a `md:col-span-5` column, using horizontal borders (`border-t border-white/10 pt-6 mt-6`) to section off header info, description, and selector components.
  * Rendered a uppercase category overline above the title and updated the title to use display-serif typography (`font-display`).
  * Extracted and formatted the base product price using `Intl.NumberFormat` on UYU currency.
  * Removed the obsolete inline WhatsApp CTA link.

## Why?
* Implements a balanced, asymmetrical editorial layout for the product detail view, enhancing the premium feel of the brand.
* Fixes mobile overlapping bugs where navigation links were hidden underneath the fixed header.
* Closes #114.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to any product details page (e.g. `/products/chaleco-polar-tecnico-dama`).
3. Verify that the layout shifts to a stacked view in mobile, and the back-to-catalog link is fully visible below the header.
4. Verify the hover zoom animation on the main image and check that it fits the container without background gaps.
