### PR TITLE
feat(detail): refine option selectors and styles

### DIFF
--- a/src/components/CartInteraction.tsx
+++ b/src/components/CartInteraction.tsx
@@ -62,16 +62,13 @@ export default function CartInteraction({ product }: { product: Product }) {
 
   return (
     <div className="flex flex-col gap-4 py-2 w-full">
-      <span>
-        {new Intl.NumberFormat("es-UY", {
-          style: "currency",
-          currency: "UYU",
-          maximumFractionDigits: 0,
-        }).format(finalPrice)}
-      </span>
       <div>
-        <h2>Color:</h2>
-        <p>{selectedColor}</p>
+        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400 mb-3 block">
+          Color:{" "}
+          <span className="text-white normal-case font-medium ml-1">
+            {selectedColor}
+          </span>
+        </span>
         <div className="flex gap-3 py-2">
           {product.colors.map((color) => (
             <label key={color.name} className="cursor-pointer">
@@ -85,7 +82,7 @@ export default function CartInteraction({ product }: { product: Product }) {
                 aria-label={`Color ${color.name}`}
               />
               <span
-                className={`w-6 h-6 inline-block rounded-full peer-checked:ring-2 peer-checked:ring-offset-2 peer-checked:ring-gray-400`}
+                className={`w-8 h-8 inline-block rounded-full border border-white/20 peer-checked:ring-2 peer-checked:ring-offset-2 peer-checked:ring-gray-400 peer-checked:ring-offset-[#07101d]`}
                 style={{ backgroundColor: color.hex }}
               ></span>
             </label>
@@ -94,7 +91,9 @@ export default function CartInteraction({ product }: { product: Product }) {
       </div>
 
       <div>
-        <h2>Seleccioná tu Talle:</h2>
+        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400 mb-3 block">
+          Seleccioná tu Talle:
+        </span>
         <div className="flex gap-2 py-2">
           {product.sizes.map((size) => (
             <label key={size.name} className="cursor-pointer">
@@ -122,7 +121,7 @@ export default function CartInteraction({ product }: { product: Product }) {
 
       <button
         type="button"
-        className={`flex items-center justify-center gap-2 text-center cursor-pointer p-2 my-2 rounded-lg w-full max-w-sm text-slate-800 font-bold transition-colors duration-300 ${isAdded ? "bg-emerald-500" : "bg-orange-400"}`}
+        className={`text-white font-bold w-full py-4 rounded-xl transition-opacity mt-4 cursor-pointer ${isAdded ? "bg-emerald-500" : "bg-brand hover:opacity-90"}`}
         onClick={handleAddToCart}
         disabled={isAdded}
       >

--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -42,7 +42,7 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
         src={product.image}
         alt={product.name}
         format="webp"
-        class={"hover:scale-[1.02] transition-transform duration-700 ease-out w-full aspect-[4/5] object-cover"}
+        class={"hover:scale-[1.02] transition-transform duration-700 ease-out w-full aspect-[4/5] object-cover will-change-transform"}
       />
     </div>
 
@@ -59,7 +59,9 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
       <p class="text-2xl font-semibold text-white mt-3">{formattedPrice}</p>
 
       <div class="border-t border-white/10 pt-6 mt-6">
-        <p class="text-sm text-slate-400 leading-relaxed mb-6">{product.description}</p>
+        <p class="text-sm text-slate-400 leading-relaxed mb-6">
+          {product.description}
+        </p>
       </div>
 
       <div class="border-t border-white/10 pt-6 mt-6">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,7 +16,7 @@
 }
 
 @utility size-selector {
-  @apply px-4 py-2 border rounded-md transition-colors peer-checked:bg-brand peer-checked:text-white;
+  @apply px-4 py-2 border border-white/15 hover:border-white/40 rounded-md transition-colors peer-checked:bg-brand peer-checked:text-white peer-checked:border-brand;
 }
 
 input:-webkit-autofill,


### PR DESCRIPTION
## What changed?
* Updated `src/components/CartInteraction.tsx` to display the selected color inline with the label, apply refined overline styles to titles, enlarge color swatches to 32px with a distinct ring offset for dark colors, style the main checkout CTA button, and remove duplicate price rendering.
* Updated `src/styles/global.css` to refine the `size-selector` utility with subtle borders, active border color, and hover transition.
* Updated `src/components/ProductDetailView.astro` to add `will-change-transform` on the main product image.

## Why?
* Standardizes selector UX and aligns CTA styles with brand guidelines.
* Resolves a subpixel rendering jump on hover-out of the product image.
* Closes #115.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to a product detail page.
3. Verify that the size, color, and "Añadir al Carrito" buttons are styled and aligned properly.
4. Hover on the product image and verify the zoom transition returns to rest without any horizontal layout shifts.

