### PR TITLE
feat(whatsapp): implement floating help widget

### DIFF
--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -5,10 +5,9 @@ import CartInteraction from "./CartInteraction";
 
 interface Props {
   product: Product;
-  wppUrl: string;
 }
 
-const { product, wppUrl } = Astro.props;
+const { product } = Astro.props;
 
 const formattedPrice = new Intl.NumberFormat("es-UY", {
   style: "currency",

--- a/src/components/WhatsAppWidget.astro
+++ b/src/components/WhatsAppWidget.astro
@@ -1,0 +1,34 @@
+---
+import { STORE_PHONE } from "../constants";
+
+const whatsappUrl = `https://wa.me/${STORE_PHONE}`;
+---
+
+<a
+  href={whatsappUrl}
+  target="_blank"
+  rel="noopener noreferrer"
+  class="group fixed bottom-4 right-4 md:bottom-6 md:right-6 z-50 flex items-center justify-center w-12 h-12 md:w-14 md:h-14 bg-[#25D366] hover:brightness-105 text-white rounded-full shadow-2xl transition-all duration-300 hover:scale-110 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#25D366] focus:ring-offset-bg"
+  aria-label="Contactar por WhatsApp"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    class="w-6 h-6 md:w-7 md:h-7 text-white fill-current"
+    role="img"
+    viewBox="0 0 24 24"
+  >
+    <title>WhatsApp</title>
+    <path
+      d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52s.198-.298.298-.497c.099-.198.05-.371-.025-.52s-.669-1.612-.916-2.207c-.242-.579-.487-.5-.669-.51a13 13 0 0 0-.57-.01c-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074s2.096 3.2 5.077 4.487c.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413s.248-1.289.173-1.413c-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.82 9.82 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.82 11.82 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.9 11.9 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.82 11.82 0 0 0-3.48-8.413"
+    ></path>
+  </svg>
+
+  <span
+    class="absolute bottom-full mb-3 right-0 bg-[#0a1628]/95 backdrop-blur-sm text-slate-200 text-xs font-medium px-4 py-2.5 rounded-xl shadow-2xl border border-white/10 whitespace-nowrap opacity-0 pointer-events-none transition-all duration-300 translate-y-2 group-hover:opacity-100 group-hover:translate-y-0 hidden md:block"
+    >¡Hola! ¿Tenés alguna duda? 💬
+
+    <span
+      class="absolute top-full -mt-[4px] right-[22px] w-2.5 h-2.5 bg-[#0a1628] border-r border-b border-white/10 rotate-45"
+    ></span>
+  </span>
+</a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import CartDrawer from "../components/CartDrawer";
 import Footer from "../components/Footer.astro";
 import Navbar from "../components/Navbar.astro";
 import ToastContainer from "../components/ToastContainer";
+import WhatsAppWidget from "../components/WhatsAppWidget.astro";
 
 interface Props {
   title?: string;
@@ -45,6 +46,7 @@ const {
       <slot />
     </main>
     <Footer />
+    <WhatsAppWidget />
   </body>
 </html>
 

--- a/src/pages/products/[slug].astro
+++ b/src/pages/products/[slug].astro
@@ -1,6 +1,5 @@
 ---
 import ProductDetailView from "../../components/ProductDetailView.astro";
-import { STORE_PHONE } from "../../constants";
 import { products } from "../../data/products";
 import Layout from "../../layouts/Layout.astro";
 
@@ -11,10 +10,6 @@ const product = products.find((prod) => prod.slug === slug);
 if (!product) {
   return Astro.redirect("/404");
 }
-
-const wppMessage = `Hola! Me interesa comprar ${product?.name}`;
-const encodedWppMessage = encodeURIComponent(wppMessage);
-const wppUrl = `https://wa.me/${STORE_PHONE}?text=${encodedWppMessage}`;
 
 export async function getStaticPaths() {
   return products.map((product) => ({
@@ -28,5 +23,5 @@ export async function getStaticPaths() {
   description={product.description}
   ogImage={product.image.src}
 >
-  <ProductDetailView product={product} wppUrl={wppUrl} />
+  <ProductDetailView product={product} />
 </Layout>


### PR DESCRIPTION
## What changed?
* Created `src/components/WhatsAppWidget.astro` to render a floating support widget with responsive sizing, a custom tooltip, and accessible focus states.
* Integrated the `WhatsAppWidget` component globally inside `src/layouts/Layout.astro`.
* Cleaned up unused `wppUrl` and obsolete logic in `src/components/ProductDetailView.astro` and `src/pages/products/[slug].astro`.

## Why?
* Decouples the support channel from the checkout flow in the product detail page, making it a persistent global channel.
* Closes #117.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Visit any page in the store (e.g. the homepage or product detail).
3. Verify that the WhatsApp floating icon appears in the bottom right corner.
4. Hover over the button and confirm that the customized tooltip ("¡Hola! ¿Tenés alguna duda? 💬") emerges smoothly.
5. Click the button to verify it links to the WhatsApp URL derived from `STORE_PHONE`.

