### PR TITLE
feat(product-detail): replace back link with chevron breadcrumbs

### DIFF
--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -17,22 +17,46 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
 ---
 
 <div class="max-w-screen-xl mx-auto px-6 pt-24 pb-10 md:pt-32 md:pb-20">
-  <a href="/" class="flex underline gap-2"
-    ><svg
+  <nav
+    class="flex items-center gap-2 mb-8 font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500"
+  >
+    <a href="/" class="hover:text-brand transition-colors duration-200"
+      >Inicio</a
+    >
+    <svg
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
-      stroke-width={1.5}
+      stroke-width="2.5"
       stroke="currentColor"
-      class="size-6"
+      class="text-slate-600 size-3"
     >
       <path
         stroke-linecap="round"
         stroke-linejoin="round"
-        d="M6.75 15.75 3 12m0 0 3.75-3.75M3 12h18"></path>
+        d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
     </svg>
-    Volver al Inicio</a
-  >
+
+    <a href="/catalog" class="hover:text-brand transition-colors duration-200"
+      >Catálogo</a
+    >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="2.5"
+      stroke="currentColor"
+      class="text-slate-600 size-3"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="m8.25 4.5 7.5 7.5-7.5 7.5"></path>
+    </svg>
+
+    <span class="text-slate-300 select-none">{product.name}</span>
+  </nav>
+
   <section class="grid grid-cols-1 md:grid-cols-12 gap-8 md:gap-12 items-start">
     <div
       class="md:col-span-7 overflow-hidden border border-white/5 bg-white/[0.02]"


### PR DESCRIPTION
## What changed?
* Updated `src/components/ProductDetailView.astro` to replace the "Volver al Inicio" link with a chevron breadcrumbs row.

## Why?
* Provides clean, accessible, and responsive breadcrumb-style navigation.
* Closes #116.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Go to any product detail page.
3. Verify that the breadcrumbs (Inicio > Catálogo > Product Name) render correctly and hover transitions work.
