### PR TITLE
feat(product-detail): implement expandable rich descriptions for products

### DIFF
--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -81,10 +81,29 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
       </h1>
       <p class="text-2xl font-semibold text-white mt-3">{formattedPrice}</p>
 
-      <div class="border-t border-white/10 pt-6 mt-6">
-        <p class="text-sm text-slate-400 leading-relaxed mb-6">
-          {product.description}
+      <div class="border-t border-white/10 pt-6 mt-6 flex flex-col gap-4">
+        <p class="text-sm text-slate-400 leading-relaxed">
+          {product.description.split("\n\n")[0]}
         </p>
+
+        <div id="extra-info" class="hidden flex flex-col gap-4">
+          {
+            product.description
+              .split("\n\n")
+              .slice(1)
+              .map((paragraph) => (
+                <p class="text-sm text-slate-400 leading-relaxed">
+                  {paragraph}
+                </p>
+              ))
+          }
+        </div>
+
+        <button
+          id="toggle-btn"
+          class="text-xs font-bold uppercase tracking-wider text-brand hover:text-white transition-colors duration-200 self-start mt-2 focus:outline-none cursor-pointer"
+          >Ver más detalles</button
+        >
       </div>
 
       <div class="border-t border-white/10 pt-6 mt-6">
@@ -93,3 +112,21 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
     </div>
   </section>
 </div>
+
+<script>
+  const toggleBtn = document.getElementById("toggle-btn");
+  const extraInfo = document.getElementById("extra-info");
+
+  if (toggleBtn && extraInfo) {
+    toggleBtn.addEventListener("click", () => {
+      const isHidden = extraInfo.classList.contains("hidden");
+      if (isHidden) {
+        extraInfo.classList.remove("hidden");
+        toggleBtn.textContent = "Ver menos";
+      } else {
+        extraInfo.classList.add("hidden");
+        toggleBtn.textContent = "Ver más detalles";
+      }
+    });
+  }
+</script>

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -10,8 +10,12 @@ export const rawProducts = [
     id: "0",
     name: "Chaleco Polar Técnico — Dama",
     price: 2500,
-    description:
-      "Chaleco de polar técnico aislante, diseño anatómico y térmico para mujer.",
+    description: `Chaleco de polar técnico de alto rendimiento con diseño anatómico entallado que se adapta a la silueta femenina. Ideal como capa intermedia o exterior en climas fríos moderados, proporcionando calidez sin restringir el movimiento.
+
+Construido con tejido polar de densidad media (200 g/m²), ofrece un excelente aislamiento térmico reteniendo el calor corporal y facilitando la evaporación del sudor. Cuenta con costuras planas anti-roce y paneles laterales elásticos para mayor comodidad.
+
+Fabricado en 100% poliéster reciclado de secado rápido, cuenta con bolsillos con cierre YKK y cuello alto reforzado con protector de mentón para evitar el paso del viento.`,
+
     image: chalecoDama,
     sizes: [{ name: "S" }, { name: "M" }, { name: "L" }, { name: "XL" }],
     colors: [
@@ -24,8 +28,12 @@ export const rawProducts = [
     id: "1",
     name: "Chaleco Polar Técnico — Caballero",
     price: 2500,
-    description:
-      "Chaleco de polar técnico aislante con detalles reforzados para hombre.",
+    description: `Chaleco polar técnico diseñado para el hombre activo, perfecto para capas térmicas en climas variables. Su corte ergonómico y hombros reforzados ofrecen durabilidad adicional y previenen el desgaste al usar mochila.
+
+Desarrollado con polar de densidad media (200 g/m²) y alta retención de calor, proporciona una barrera efectiva contra el frío manteniendo una excelente transpirabilidad durante actividades de alta intensidad.
+
+Confeccionado con fibras sintéticas de poliéster de alta resistencia, incorpora tres bolsillos externos con cierre térmico, cordón de ajuste elástico en el dobladillo para sellar el calor y cuello alto con protección contra el viento.
+`,
     image: chalecoCaballero,
     sizes: [{ name: "S" }, { name: "M" }, { name: "L" }, { name: "XL" }],
     colors: [
@@ -38,8 +46,12 @@ export const rawProducts = [
     id: "2",
     name: "Campera de Expedición Polar — Dama",
     price: 4900,
-    description:
-      "Campera térmica de polar de alta densidad para mujer, con cierre completo y protección contra viento.",
+    description: `Campera térmica de expedición diseñada para brindar protección extrema a mujeres en condiciones de frío intenso. Su silueta estilizada y ergonómica permite un ajuste cómodo tanto sola como debajo de una campera impermeable.
+
+Fabricada con polar de alta densidad (300 g/m²), esta prenda destaca por su capacidad de aislamiento térmico superior. Incorpora una membrana cortaviento interna en el pecho y espalda que bloquea las ráfagas heladas sin comprometer la respirabilidad.
+
+El material es poliéster premium con tratamiento antipilling (antipelusa) de larga duración. Cuenta con puños elásticos ajustados, bolsillos laterales con cierre para calentar las manos y un cuello alto protector con forro de microfibra ultrasuave.
+`,
     image: camperaDama,
     sizes: [{ name: "S" }, { name: "M" }, { name: "L" }, { name: "XL" }],
     colors: [
@@ -52,8 +64,12 @@ export const rawProducts = [
     id: "3",
     name: "Campera de Expedición Polar — Caballero",
     price: 4900,
-    description:
-      "Campera térmica de polar de alta densidad para hombre, con bolsillos reforzados y cierre completo.",
+    description: `Campera térmica de alta gama concebida para expediciones y actividades de montaña bajo climas severos. Diseñada con un corte atlético y refuerzos ripstop (antidesgarro) en hombros y codos para resistir la abrasión en terrenos difíciles.
+
+Su confección en tejido polar ultra-denso (300 g/m²) retiene de manera excepcional la temperatura corporal en reposo y movimiento. La estructura del tejido proporciona un escudo cortaviento eficiente y una excelente resistencia a lloviznas ligeras.
+
+Elaborada con materiales sintéticos de alto desempeño técnico, incluye cierre frontal completo con solapa interior, puños ajustables con velcro, múltiples bolsillos de seguridad con cierre y un dobladillo ajustable mediante cordón elástico.
+`,
     image: camperaCaballero,
     sizes: [{ name: "S" }, { name: "M" }, { name: "L" }, { name: "XL" }],
     colors: [

--- a/src/pages/products/[slug].astro
+++ b/src/pages/products/[slug].astro
@@ -20,7 +20,7 @@ export async function getStaticPaths() {
 
 <Layout
   title={product.name}
-  description={product.description}
+  description={product.description.split("\n\n")[0]}
   ogImage={product.image.src}
 >
   <ProductDetailView product={product} />


### PR DESCRIPTION
## What changed?
* Updated `src/data/products.ts` with multi-paragraph descriptions in Spanish outlining technical specifications, garment performance, and materials for all four products.
* Updated `src/components/ProductDetailView.astro` to render the first paragraph as always visible, wrap subsequent paragraphs in a collapsible container, and added a client-side vanilla JavaScript toggle button to show or hide the details.
* Updated `src/pages/products/[slug].astro` to pass only the first paragraph of the product description to the `Layout` metadata for SEO compatibility.

## Why?
* Shop administrators need rich, detailed descriptions for products so that pages look informative and premium.
* Keeping extra paragraphs collapsed by default prevents long text from pushing key purchasing actions (size selection, add to cart button) below the fold on mobile screens (improving conversion rate).
* Passing only the first paragraph to metadata prevents malformed and excessively long description tags on search engines and social previews.
* Closes #118.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to any product page (e.g., `/products/chaleco-polar-tecnico-dama`).
3. Verify that only the first paragraph of the description is visible.
4. Click on the "Ver más detalles" button and verify the extra paragraphs expand smoothly with consistent spacing.
5. Click on the "Ver menos" button to collapse the details back to the first paragraph.
6. Inspect the page source and check that the `<meta name="description">` tag contains only the first paragraph without newlines.
