### PR TITLE
style(size-guide): refine trigger aesthetics and add ruler icon

### DIFF
--- a/src/components/CartInteraction.tsx
+++ b/src/components/CartInteraction.tsx
@@ -91,9 +91,37 @@ export default function CartInteraction({ product }: { product: Product }) {
       </div>
 
       <div>
-        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400 mb-3 block">
-          Seleccioná tu Talle:
-        </span>
+        <div className="flex justify-between items-baseline w-full mb-3">
+          <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Seleccioná tu Talle:
+          </span>
+          <button
+            type="button"
+            className="text-xs text-slate-300 hover:text-brand transition-colors font-medium flex items-center gap-1.5 cursor-pointer"
+            onClick={() => setIsModalOpen(true)}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <title>Regla</title>
+              <path d="M5 5h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Z" />
+              <path d="M19 17v-4" />
+              <path d="M15 17v-2" />
+              <path d="M11 17v-4" />
+              <path d="M7 17v-2" />
+            </svg>
+            Abrir Guía de Talles
+          </button>
+        </div>
+
         <div className="flex gap-2 py-2">
           {product.sizes.map((size) => (
             <label key={size.name} className="cursor-pointer">
@@ -109,14 +137,6 @@ export default function CartInteraction({ product }: { product: Product }) {
             </label>
           ))}
         </div>
-
-        <button
-          type="button"
-          className="text-brand underline cursor-pointer mt-3 inline-block hover:text-orange-400 transition-colors"
-          onClick={() => setIsModalOpen(true)}
-        >
-          Abrir Guía de Talles
-        </button>
       </div>
 
       <button


### PR DESCRIPTION
## What changed?
* Updated `src/components/CartInteraction.tsx` to relocate the "Abrir Guía de Talles" trigger button to the size selector header row.
* Wrapped the header text and size guide button in a flexbox container.
* Styled the size guide button for improved hierarchy and added a miniature ruler SVG icon with a `<title>` tag for accessibility.

## Why?
* Resolves the aesthetic disconnect of the orange underlined link below the sizes, presenting it as a clean, integrated utility.
* Closes #123.

## How to test
1. Ensure the development server is running (`pnpm dev`).
2. Open any product detail page.
3. Verify that the "Abrir Guía de Talles" button displays inline with the header, includes the ruler icon, and successfully opens the sizing guide modal.
4. 