### PR TITLE
fix(product-detail): resolve accordion toggle conflict

### DIFF
--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -86,17 +86,19 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
           {product.description.split("\n\n")[0]}
         </p>
 
-        <div id="extra-info" class="hidden flex flex-col gap-4">
-          {
-            product.description
-              .split("\n\n")
-              .slice(1)
-              .map((paragraph) => (
-                <p class="text-sm text-slate-400 leading-relaxed">
-                  {paragraph}
-                </p>
-              ))
-          }
+        <div id="extra-info" class="hidden">
+          <div class="flex flex-col gap-4">
+            {
+              product.description
+                .split("\n\n")
+                .slice(1)
+                .map((paragraph) => (
+                  <p class="text-sm text-slate-400 leading-relaxed">
+                    {paragraph}
+                  </p>
+                ))
+            }
+          </div>
         </div>
 
         <button


### PR DESCRIPTION
## What changed?
* Updated `src/components/ProductDetailView.astro` to wrap expandable paragraphs in an inner container with flex layout styles, leaving the outer container `#extra-info` responsible only for toggling visibility.

## Why?
* Prevents Tailwind's `flex` layout class from overriding the `hidden` class on the accordion element, which was keeping the description expanded at all times.
* Closes #126.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to a product detail page.
3. Click "Ver más detalles" to expand and collapse the description content, verifying that it toggles visibility correctly.
