### PR TITLE
style(product-detail): address mobile layout and responsiveness issues

### DIFF
--- a/src/components/ProductDetailView.astro
+++ b/src/components/ProductDetailView.astro
@@ -18,7 +18,7 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
 
 <div class="max-w-screen-xl mx-auto px-6 pt-24 pb-10 md:pt-32 md:pb-20">
   <nav
-    class="flex items-center gap-2 mb-8 font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500"
+    class="flex flex-wrap items-center gap-2 mb-8 font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-slate-500"
   >
     <a href="/" class="hover:text-brand transition-colors duration-200"
       >Inicio</a
@@ -59,7 +59,7 @@ const formattedPrice = new Intl.NumberFormat("es-UY", {
 
   <section class="grid grid-cols-1 md:grid-cols-12 gap-8 md:gap-12 items-start">
     <div
-      class="md:col-span-7 overflow-hidden border border-white/5 bg-white/[0.02]"
+      class="max-h-[60vh] md:max-h-none md:col-span-7 overflow-hidden border border-white/5 bg-white/[0.02]"
     >
       <Image
         src={product.image}

--- a/src/components/SizeChartModal.tsx
+++ b/src/components/SizeChartModal.tsx
@@ -69,43 +69,48 @@ export default function SizeChartModal({
           </button>
         </div>
 
-        <table className="w-full border-collapse mt-6 text-left text-sm">
-          <thead>
-            <tr>
-              <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
-                Talle
-              </th>
-              <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
-                Pecho (cm)
-              </th>
-              <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
-                Cintura (cm)
-              </th>
-              <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
-                Cadera (cm)
-              </th>
-            </tr>
-          </thead>
-
-          <tbody>
-            {SIZE_CHART.map((row) => (
-              <tr key={row.name} className="hover:bg-white/5 transition-colors">
-                <td className="py-3 border-b border-white/5 text-slate-400">
-                  {row.name}
-                </td>
-                <td className="py-3 border-b border-white/5 text-slate-400">
-                  {row.chest}
-                </td>
-                <td className="py-3 border-b border-white/5 text-slate-400">
-                  {row.waist}
-                </td>
-                <td className="py-3 border-b border-white/5 text-slate-400">
-                  {row.hip}
-                </td>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[400px] border-collapse mt-6 text-left text-sm">
+            <thead>
+              <tr>
+                <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
+                  Talle
+                </th>
+                <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
+                  Pecho (cm)
+                </th>
+                <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
+                  Cintura (cm)
+                </th>
+                <th className="border-b border-white/10 pb-3 text-slate-300 font-semibold">
+                  Cadera (cm)
+                </th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+
+            <tbody>
+              {SIZE_CHART.map((row) => (
+                <tr
+                  key={row.name}
+                  className="hover:bg-white/5 transition-colors"
+                >
+                  <td className="py-3 border-b border-white/5 text-slate-400">
+                    {row.name}
+                  </td>
+                  <td className="py-3 border-b border-white/5 text-slate-400">
+                    {row.chest}
+                  </td>
+                  <td className="py-3 border-b border-white/5 text-slate-400">
+                    {row.waist}
+                  </td>
+                  <td className="py-3 border-b border-white/5 text-slate-400">
+                    {row.hip}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
 
         <div className="mt-6 pt-6 border-t border-white/10">
           <h3 className="text-xs font-semibold uppercase tracking-wider text-brand mb-3">


### PR DESCRIPTION
## What changed?
* Updated `src/components/ProductDetailView.astro` to add `flex-wrap` to the breadcrumb `<nav>` container and `max-h-[60vh] md:max-h-none` to the product image wrapper.
* Updated `src/components/SizeChartModal.tsx` to wrap the `SIZE_CHART` table in an `overflow-x-auto` container and applied `min-w-[400px]` to the `<table>` element.

## Why?
* Prevents horizontal layout overflow on mobile viewports smaller than 400px.
* Limits the product image height on mobile viewports to prevent excessive scrolling while ensuring it remains full-height on desktop.
* Avoids size chart table column compression on narrow screens by making the table scroll horizontally.
* Closes #128.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to any product detail page (e.g., `/products/buzo-polar`).
3. Toggle mobile view in browser devtools and check that the product image doesn't overflow the viewport height and the breadcrumbs wrap nicely.
4. Open the size chart modal and verify that the table scroll is enabled horizontally without column compression on narrow viewports.
