### PR TITLE
refactor(data): decouple size chart and FAQ content into dedicated data models

### DIFF
--- a/src/components/SizeChartModal.tsx
+++ b/src/components/SizeChartModal.tsx
@@ -1,31 +1,5 @@
+import { SIZE_CHART } from "../data/sizeChart";
 import Modal from "./Modal";
-
-const SIZE_CHART = [
-  {
-    name: "S",
-    chest: "88 - 94",
-    waist: "76 - 82",
-    hip: "88 - 94",
-  },
-  {
-    name: "M",
-    chest: "95 - 101",
-    waist: "83 - 89",
-    hip: "95 - 101",
-  },
-  {
-    name: "L",
-    chest: "102 - 108",
-    waist: "90 - 96",
-    hip: "102 - 108",
-  },
-  {
-    name: "XL",
-    chest: "109 - 115",
-    waist: "97 - 103",
-    hip: "109 - 115",
-  },
-];
 
 export default function SizeChartModal({
   isOpen,

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -1,0 +1,22 @@
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+export const FAQ_LIST: FAQItem[] = [
+  {
+    question: "¿Cuáles son los métodos de envío?",
+    answer:
+      "Realizamos envíos a todo el país a través de las principales agencia de carga (DAC, Mirtrans).",
+  },
+  {
+    question: "¿Tienen local físico para probarse la ropa?",
+    answer:
+      "Actualmente operamos de manera 100% online. Esto nos permite optimizar costos y ofrecerte la mejor relación calidad-precio en equipamiento térmico. Si tenés dudas con tu talle, podés escribirnos y te asesoramos.",
+  },
+  {
+    question: "¿Cómo realizo un cambio de talle o modelo?",
+    answer:
+      "Tenés hasta 30 días corridos desde que recibís tu compra para realizar cambios. Escribinos a través de nuestra página de contacto o directamente por WhatsApp con tu número de pedido y coordinamos el envío.",
+  },
+];

--- a/src/data/sizeChart.ts
+++ b/src/data/sizeChart.ts
@@ -1,0 +1,33 @@
+export const SIZE_CHART: SizeChartRow[] = [
+  {
+    name: "S",
+    chest: "88 - 94",
+    waist: "76 - 82",
+    hip: "88 - 94",
+  },
+  {
+    name: "M",
+    chest: "95 - 101",
+    waist: "83 - 89",
+    hip: "95 - 101",
+  },
+  {
+    name: "L",
+    chest: "102 - 108",
+    waist: "90 - 96",
+    hip: "102 - 108",
+  },
+  {
+    name: "XL",
+    chest: "109 - 115",
+    waist: "97 - 103",
+    hip: "109 - 115",
+  },
+];
+
+export interface SizeChartRow {
+  name: string;
+  chest: string;
+  waist: string;
+  hip: string;
+}

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,4 +1,5 @@
 ---
+import { FAQ_LIST } from "../data/faq";
 import Layout from "../layouts/Layout.astro";
 ---
 
@@ -19,39 +20,22 @@ import Layout from "../layouts/Layout.astro";
     </p>
 
     <div class="divide-y divide-white/[0.06]">
-      <div class="pb-8">
-        <h3 class="text-base font-bold text-white">
-          ¿Cuáles son los métodos de envío?
-        </h3>
-        <p class="text-sm text-slate-400 mt-2 leading-relaxed">
-          Realizamos envíos a todo el país a través de las principales agencias
-          de carga (DAC, Mirtrans).
-        </p>
-      </div>
-
-      <div class="py-8">
-        <h3 class="text-base font-bold text-white">
-          ¿Tienen local físico para probarse la ropa?
-        </h3>
-        <p class="text-sm text-slate-400 mt-2 leading-relaxed">
-          Actualmente operamos de manera 100% online. Esto nos permite optimizar
-          costos y ofrecerte la mejor relación calidad-precio en equipamiento
-          térmico. Si tenés dudas con tu talle, podés escribirnos y te
-          asesoramos.
-        </p>
-      </div>
-
-      <div class="pt-8">
-        <h3 class="text-base font-bold text-white">
-          ¿Cómo realizo un cambio de talle o modelo?
-        </h3>
-        <p class="text-sm text-slate-400 mt-2 leading-relaxed">
-          Tenés hasta 30 días corridos desde que recibís tu compra para realizar
-          cambios. Escribinos a través de nuestra página de contacto o
-          directamente por WhatsApp con tu número de pedido y coordinamos el
-          envío.
-        </p>
-      </div>
+      {
+        FAQ_LIST.map((faq, index) => (
+          <div
+            class:list={{
+              "pb-8": index === 0,
+              "py-8": index > 0 && index < FAQ_LIST.length - 1,
+              "pt-8": index === FAQ_LIST.length - 1,
+            }}
+          >
+            <h3 class="text-base font-bold text-white">{faq.question}</h3>
+            <p class="text-sm text-slate-400 mt-2 leading-relaxed">
+              {faq.answer}
+            </p>
+          </div>
+        ))
+      }
     </div>
   </div>
 </Layout>


### PR DESCRIPTION
## What changed?
* Added `src/data/sizeChart.ts` to export the structured size chart rows.
* Updated `src/components/SizeChartModal.tsx` to import and consume the extracted size chart data.
* Added `src/data/faq.ts` to house the FAQ list.
* Updated `src/pages/faq.astro` to map dynamically over the FAQ data using `class:list` for responsive padding.

## Why?
* Decouples data models from presentation layouts, improving component readability and separation of concerns.
* Closes #109.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Open the size chart modal on any product page and verify the measurements table displays correctly.
3. Navigate to `/faq` and check that all questions are rendered with their corresponding responsive paddings.
