### PR TITLE
feat(navigation): resolve broken legal links and update social media anchors in footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -162,13 +162,13 @@ import { STORE_FACEBOOK, STORE_INSTAGRAM, STORE_TIKTOK } from "../constants";
       </span>
       <div class="flex gap-6">
         <a
-          href="/privacidad"
+          href="/privacy"
           class="font-sans text-[10px] uppercase tracking-wider text-slate-500 hover:text-slate-300 transition-colors duration-200"
         >
           Políticas de Privacidad
         </a>
         <a
-          href="/terminos"
+          href="/terms"
           class="font-sans text-[10px] uppercase tracking-wider text-slate-500 hover:text-slate-300 transition-colors duration-200"
         >
           Términos de Servicio

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,5 +5,5 @@ export const STORE_EMAIL = "abrigatebien@gmail.com";
 export const STORE_SCHEDULE = "Lunes a Viernes de 9:00 a 18:00 hs";
 export const STORE_COVERAGE = "Uruguay (Envíos a todo el país)";
 export const STORE_INSTAGRAM = "https://www.instagram.com/abrigate-bien-store";
-export const STORE_FACEBOOK = "https://www.faceboook.com/abrigate-bien-store";
+export const STORE_FACEBOOK = "https://www.facebook.com/abrigate-bien-store";
 export const STORE_TIKTOK = "https://www.tiktok.com/abrigate-bien-store";

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,31 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="Políticas de Privacidad | Abrígate Bien 🔥">
+  <div class="max-w-screen-md mx-auto px-6 pt-32 pb-20">
+    <p
+      class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-brand mb-2"
+    >
+      Legales
+    </p>
+    <h1
+      class="font-display text-white text-3xl md:text-4xl font-bold leading-tight mb-6"
+    >
+      Políticas de Privacidad
+    </h1>
+    <div class="text-sm text-slate-400 leading-relaxed space-y-4">
+      <p>
+        En Abrígate Bien nos comprometemos a proteger la privacidad de nuestros
+        usuarios. Esta página contiene información sobre el tratamiento de tus
+        datos personales en nuestra tienda.
+      </p>
+      <p>
+        Los datos recopilados (como los productos de tu carrito) se utilizan
+        únicamente con el fin de armar tu pedido para que puedas finalizar tu
+        compra de manera sencilla a través de WhatsApp. No vendemos ni
+        compartimos tu información con terceros.
+      </p>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,31 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="Términos de Servicio | Abrígate Bien 🔥">
+  <div class="max-w-screen-md mx-auto px-6 pt-32 pb-20">
+    <p
+      class="font-sans text-[10px] font-bold uppercase tracking-[0.2em] text-brand mb-2"
+    >
+      Legales
+    </p>
+    <h1
+      class="font-display text-white text-3xl md:text-4xl font-bold leading-tight mb-6"
+    >
+      Términos de Servicio
+    </h1>
+    <div class="text-sm text-slate-400 leading-relaxed space-y-4">
+      <p>
+        Bienvenido a Abrígate Bien. Al ingresar utilizando nuestro sitio web,
+        estás aceptando los términos y condiciones de uso descriptos en esta
+        sección.
+      </p>
+      <p>
+        Nuestra plataforma sirve como catálogo interactivo. Las compras finales
+        se procesan mediante derivación a nuestro canal de WhatsApp. Nos
+        reservamos el derecho a actualizar precios, stock y características de
+        los productos sin previo aviso.
+      </p>
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
## What changed?
* Corrected the misspelled Facebook official URL in `src/constants.ts`.
* Updated `src/components/Footer.astro` to route the legal navigation links to English-named pages (`/privacy` and `/terms`).
* Added `src/pages/privacy.astro` and `src/pages/terms.astro` to serve as functional placeholder pages for privacy policy and terms of service.

## Why?
* Prevents 404 console errors on the client when clicking the legal documents in the footer.
* Ensures the Facebook community link routes successfully to the official store profile.
* Closes #107.

## How to test
1. Ensure the development server is running (`pnpm dev`).
2. Scroll to the footer and click on the "Políticas de Privacidad" link. Verify it redirects to `/privacy` with a 200 OK status.
3. Click on the "Términos de Servicio" link. Verify it redirects to `/terms` with a 200 OK status.
4. Verify the Facebook icon routes to `https://www.facebook.com/abrigate-bien-store` instead of the broken domain.
