### PR TITLE
feat(cart): improve accessibility of trigger and drawer buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # agent rules
 .agents
+.gga
 
 # build output
 dist/

--- a/src/components/CartDrawerView.tsx
+++ b/src/components/CartDrawerView.tsx
@@ -46,12 +46,11 @@ export default function CartDrawerView({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth="1.75"
-              aria-labelledby="title"
               className="icon icon-tabler icons-tabler-outline icon-tabler-x cursor-pointer"
               role="img"
               viewBox="0 0 24 24"
             >
-              <title>Borrar producto del carrito</title>
+              <title>Cerrar carrito</title>
               <path fill="none" stroke="none" d="M0 0h24v24H0z" />
               <path d="M18 6 6 18M6 6l12 12" />
             </svg>
@@ -76,7 +75,8 @@ export default function CartDrawerView({
 
                 <button
                   type="button"
-                  title="Close"
+                  title={`Quitar una unidad de ${item.name}`}
+                  aria-label={`Quitar una unidad de ${item.name}`}
                   onClick={() =>
                     onRemoveItem(`${item.id}-${item.size}-${item.color}`)
                   }

--- a/src/components/CartIcon.tsx
+++ b/src/components/CartIcon.tsx
@@ -43,6 +43,7 @@ export default function CartIcon() {
     <button
       type="button"
       className="relative bg-transparent border-none cursor-pointer focus:outline-none focus-visible:ring focus-visible:ring-amber-500 rounded-lg"
+      aria-label={`Carrito de compras, ${totalItems} productos`}
       onClick={() => toggleCart()}
     >
       <svg
@@ -57,7 +58,7 @@ export default function CartIcon() {
         strokeLinejoin="round"
         className="icon icon-tabler icons-tabler-outline icon-tabler-shopping-bag"
       >
-        <title>Shopping Bag</title>
+        <title>Carrito de compras</title>
         <path stroke="none" d="M0 0h24v24H0z" fill="none" />
         <path d="M6.331 8h11.339a2 2 0 0 1 1.977 2.304l-1.255 8.152a3 3 0 0 1 -2.966 2.544h-6.852a3 3 0 0 1 -2.965 -2.544l-1.255 -8.152a2 2 0 0 1 1.977 -2.304" />
         <path d="M9 11v-5a3 3 0 0 1 6 0v5" />


### PR DESCRIPTION
## What changed?
* Updated `src/components/CartIcon.tsx` to add a dynamic `aria-label` to the main trigger button and translated the SVG title to Spanish.
* Updated `src/components/CartDrawerView.tsx` to remove the invalid `aria-labelledby` attribute from the close button SVG and corrected its title to "Cerrar carrito".
* Added dynamic Spanish `title` and `aria-label` attributes to the remove item button in `src/components/CartDrawerView.tsx`.

## Why?
* This improves shopping cart accessibility for keyboard and screen reader users by providing descriptive Spanish labels.
* Closes #133.

## How to test
1. Ensure the development server is running (`npm run dev`).
2. Interact with the shopping cart trigger button and verify the dynamic label changes according to the number of items.
3. Open the drawer and inspect the close and remove item buttons to confirm they have the correct a11y attributes.
