### PR TITLE
feat: add post-merge hook for automated netlify deploy

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,3 +5,16 @@ pre-commit:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,astro}"
       run: pnpm biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
       stage_fixed: true
+
+post-merge:
+  commands:
+    build-deploy:
+      run: |
+        BRANCH=$(git branch --show-current)
+        if [ "$BRANCH" = "main" ]; then
+          echo "Actualización en main detectada. Compilando y desplegando a Netlify..."
+          pnpm run build && pnpm exec netlify deploy --prod --dir=dist
+        else
+          echo "Rama actual ($BRANCH) no es main. Se omite el deploy."
+        fi
+


### PR DESCRIPTION
Agrega un hook post-merge usando Lefthook para compilar y desplegar automáticamente en Netlify cada vez que se actualiza la rama \main\.