### PR TITLE
feat: add post-merge hook for automated netlify deploy

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,3 +5,16 @@ pre-commit:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,astro}"
       run: pnpm biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
       stage_fixed: true
+
+post-merge:
+  commands:
+    build-deploy:
+      run: |
+        BRANCH=$(git branch --show-current)
+        if [ "$BRANCH" = "main" ]; then
+          echo "Actualización en main detectada. Compilando y desplegando a Netlify..."
+          pnpm run build && pnpm exec netlify deploy --prod --dir=dist
+        else
+          echo "Rama actual ($BRANCH) no es main. Se omite el deploy."
+        fi
+


### PR DESCRIPTION
## Description
This PR configures a Git `post-merge` hook using **Lefthook** to automatically build and deploy to Netlify whenever changes are pulled or merged into the `main` branch.

### Key Changes
- Added a `post-merge` configuration to `lefthook.yml`.
- Integrated a hook script that:
  - Detects the current active branch using `git branch --show-current`.
  - Runs `pnpm run build && pnpm exec netlify deploy --prod --dir=dist` only when updates are integrated into `main`.
  - Skips execution on other development branches to save time and resources.

## Setup Instructions

After merging, local contributors need to run the following command to register the new hook:
```bash
pnpm lefthook install
