### PR TITLE
fix(git-hooks): fix post-merge deploy syntax error on Windows

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,12 +9,5 @@ pre-commit:
 post-merge:
   commands:
     build-deploy:
-      run: |
-        BRANCH=$(git branch --show-current)
-        if [ "$BRANCH" = "main" ]; then
-          echo "Actualización en main detectada. Compilando y desplegando a Netlify..."
-          pnpm run build && pnpm exec netlify deploy --prod --dir=dist
-        else
-          echo "Rama actual ($BRANCH) no es main. Se omite el deploy."
-        fi
+      run: node scripts/post-merge.js
 

--- a/scripts/post-merge.js
+++ b/scripts/post-merge.js
@@ -1,0 +1,21 @@
+import { execSync } from "node:child_process";
+
+try {
+  const branch = execSync("git branch --show-current", {
+    encoding: "utf8",
+  }).trim();
+
+  if (branch === "main") {
+    console.log(
+      "Actualización en main detectada. Compilando y desplegando a Netlify...",
+    );
+    execSync("pnpm run build && pnpm exec netlify deploy --prod --dir=dist", {
+      stdio: "inherit",
+    });
+  } else {
+    console.log(`Rama actual (${branch}) no es main. Se omite el deploy.`);
+  }
+} catch (error) {
+  console.error("Error al ejecutar el script de deploy:", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
### Description
Fixed a syntax error (`unexpected end of file`) that occurred on Windows during the `post-merge` hook execution. The issue was caused by Git Bash (`sh`) on Windows failing to parse carriage return characters (`\r`) inside inline multiline bash scripts defined in `lefthook.yml`.

### Changes
1. **Node.js script transition**: Replaced the inline multiline bash command with a cross-platform Node.js script located at `scripts/post-merge.js`.
2. **Lefthook configuration**: Updated `lefthook.yml` to trigger the script using `node scripts/post-merge.js`.

### Verification
- Verified execution locally on Windows. The automatic build and Netlify deployment were completed successfully.