### PR TITLE
perf(layout): defer hydration of global components in Layout.astro

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -48,8 +48,8 @@ const {
   </head>
   <body class="flex flex-col min-h-screen text-body bg-bg">
     <Navbar />
-    <CartDrawer client:load />
-    <ToastContainer client:load />
+    <CartDrawer client:idle />
+    <ToastContainer client:idle />
     <main class="flex-grow">
       <slot />
     </main>


### PR DESCRIPTION
## What changed?
* Changed the hydration directive of `<CartDrawer />` from `client:load` to `client:idle` in `src/layouts/Layout.astro`.
* Changed the hydration directive of `<ToastContainer />` from `client:load` to `client:idle` in `src/layouts/Layout.astro`.

## Why?
* Deferring the hydration of off-screen global components to idle time reduces the main thread blocking time during the initial page load, optimizing Total Blocking Time (TBT) and First Input Delay (FID).
* Closes #135.

## How to test
1. Ensure the development server is running (`pnpm run dev`).
2. Navigate to the store homepage (`http://localhost:4321`).
3. Click the cart icon in the navbar to verify the `CartDrawer` opens and closes successfully.
4. Add any product to the cart to verify that the Toast notification appears correctly and the cart state updates as expected.
